### PR TITLE
Document May 2026 features and add Leadbay MCP install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ _Do they hire seasonally? Do they have a CRM? Are they expanding?_
 {% content-ref url="product-guides/ai-assistant.md" %}
 [ai-assistant.md](product-guides/ai-assistant.md)
 {% endcontent-ref %}
+
+{% content-ref url="product-guides/leadbay-mcp.md" %}
+[leadbay-mcp.md](product-guides/leadbay-mcp.md)
+{% endcontent-ref %}

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,6 +13,7 @@
 * [Export](product-guides/export.md)
 * [Data Sources](product-guides/data-sources.md)
 * [SFTP Connector](product-guides/sftp-connector.md)
+* [Leadbay MCP for Claude](product-guides/leadbay-mcp.md)
 * [Team & Organization](product-guides/team-management.md)
 * [Manager Dashboard](product-guides/manager-dashboard.md)
 * [Install Mobile App](product-guides/install-mobile-app.md)

--- a/fr/README.md
+++ b/fr/README.md
@@ -27,3 +27,7 @@ _Recrutent-ils de manière saisonnière ? Ont-ils un CRM ? Sont-ils en croissanc
 {% content-ref url="product-guides/ai-assistant.md" %}
 [ai-assistant.md](product-guides/ai-assistant.md)
 {% endcontent-ref %}
+
+{% content-ref url="product-guides/leadbay-mcp.md" %}
+[leadbay-mcp.md](product-guides/leadbay-mcp.md)
+{% endcontent-ref %}

--- a/fr/SUMMARY.md
+++ b/fr/SUMMARY.md
@@ -13,6 +13,7 @@
 * [Export](product-guides/export.md)
 * [Sources de données](product-guides/data-sources.md)
 * [Connecteur SFTP](product-guides/sftp-connector.md)
+* [Leadbay MCP pour Claude](product-guides/leadbay-mcp.md)
 * [Équipe & Organisation](product-guides/team-management.md)
 * [Tableau de bord Manager](product-guides/manager-dashboard.md)
 * [Installer l'application mobile](product-guides/install-mobile-app.md)

--- a/fr/news/changelog.md
+++ b/fr/news/changelog.md
@@ -4,6 +4,17 @@ Leadbay publie des mises à jour chaque semaine. Voici les étapes majeures.
 
 ---
 
+## Mai 2026
+
+- **Contacts épinglés dans la fiche lead** : épinglez les contacts qui comptent pour votre prise de contact en haut de la fiche. Le slot du contact recommandé continue d'apparaître automatiquement quand rien n'est épinglé ; épinglez-en un et il prend sa place. Plusieurs contacts peuvent être épinglés à la fois. Les pins sont au niveau de l'organisation, donc votre équipe voit la même priorisation.
+- **Filtres style Notion dans Monitor** : un popover de filtres focalisé en haut à droite de Monitor. Ajoutez autant de filtres que nécessaire avec des lignes [champ] [opérateur] [valeur], combinées en AND. Le sélecteur de champs est groupé en champs standards (Localisation, Secteur, Taille, Dernière action, Date de dernière action) et champs personnalisés CRM. Les valeurs texte des champs personnalisés s'auto-complètent depuis vos données.
+- **Vue Monitor à l'échelle de l'organisation** : un nouveau toggle **Inclure les leads provenant de l'organisation** en haut du popover de filtres de Monitor fait remonter les leads avec lesquels vos coéquipiers ont interagi — en plus des vôtres — pour une vue pipeline complète. Combinez-le avec **Uniquement les leads aimés** pour rester focalisé.
+- **Rôle Manager** : lors de l'invitation d'un membre, vous pouvez désormais le marquer comme **Manager** pour qu'il obtienne la visibilité sur l'activité de son équipe dans le Dashboard Manager. Le tableau des membres a une nouvelle colonne **Manager** indiquant qui supervise qui. Le compteur de sièges sur la page Organisation indique aussi combien sont managers.
+- **Déconnexion — cet appareil ou tous les appareils** : cliquer sur **Déconnexion** ouvre désormais un dialogue demandant si vous voulez vous déconnecter uniquement de cette session ou de chaque appareil et session de token agent/API d'un coup.
+- **Intégration Salesforce** : une nouvelle option Salesforce apparaît dans le sélecteur d'intégrations aux côtés de Zapier et SFTP — connectez vos données CRM directement.
+- **Affichage du score final affiné** : la décomposition du score sur les fiches leads a été resserrée — plus facile à lire en un coup d'œil.
+- **Serveur MCP Leadbay** : un tout nouveau serveur **Model Context Protocol** permet à Claude (Desktop, Code, Cowork) de récupérer des leads, les qualifier, enrichir des contacts et journaliser les actions de prospection pour vous — en utilisant votre compte Leadbay. Voir [Leadbay MCP](../product-guides/leadbay-mcp.md) pour le guide d'installation.
+
 ## Avril 2026
 
 - **Connecteur SFTP** : connectez un serveur SFTP pour synchroniser automatiquement un fichier CSV avec vos leads. Leadbay détecte les modifications et ne ré-importe que si le fichier a changé. Réservé aux admins.
@@ -13,6 +24,7 @@ Leadbay publie des mises à jour chaque semaine. Voici les étapes majeures.
 - **Recherche globale** : appuyez sur ⌘K (Mac) ou Ctrl+K pour rechercher des leads dans Discover, Monitor et Activate. Des suggestions apparaissent au fil de la saisie.
 
 <figure><img src="../../.gitbook/assets/screenshot-search.png" alt="Recherche globale avec suggestions"><figcaption><p>Recherchez des leads par nom — des suggestions apparaissent au fil de la saisie</p></figcaption></figure>
+
 - **Suivi des enrichissements échoués** : les fiches contacts indiquent désormais quels canaux d'enrichissement ont échoué, avec possibilité de relancer et info-bulles de date d'échec. Les contacts déjà échoués peuvent être ignorés lors de l'enrichissement en masse.
 - **Gestion des champs personnalisés** : les admins peuvent désormais ajouter et modifier des champs personnalisés directement depuis les paramètres Data Sources.
 

--- a/fr/overview/best-practice-guides/leadbay-for-sales-reps.md
+++ b/fr/overview/best-practice-guides/leadbay-for-sales-reps.md
@@ -89,7 +89,7 @@ C'est votre terrain de jeu :
 
 * ouvrez la fiche d'un lead
 * demandez à l'IA de vous aider à le qualifier
-* lancez une recherche web
+* lancez une recherche web (Requalify)
 * préparez votre premier message ou votre appel
 
 💡 **Astuce Leadbay :** le chat IA vous aide à passer de la « découverte » au « contact » avec des insights très contextuels.

--- a/fr/product-guides/discover-monitor-activate.md
+++ b/fr/product-guides/discover-monitor-activate.md
@@ -31,6 +31,7 @@ Des leads recommandés par l'IA en fonction de votre ICP (Ideal Customer Profile
 | Description | Court résumé généré par l'IA |
 | Localisation | Ville / région |
 | Taille | Tranche d'effectifs |
+| Contact recommandé | Le meilleur contact connu par Leadbay — cliquez pour l'enrichir |
 | Data | Indicateur de complétude des données |
 
 **Actions principales :**
@@ -38,6 +39,7 @@ Des leads recommandés par l'IA en fonction de votre ICP (Ideal Customer Profile
 - **Like** (pouce vers le haut) : indique au modèle « montre-moi des leads similaires ». Le lead passe dans Activate.
 - **Dislike** (pouce vers le bas) : indique au modèle « pas pertinent ». Le lead est retiré de Discover.
 - **Cliquer sur un lead** pour ouvrir sa fiche et consulter les détails avant de décider.
+- **Sélectionnez des leads** via la colonne de cases à cocher, puis utilisez la barre d'actions flottante pour **Qualify**, **Enrichir** ou **Exporter**.
 
 <figure><img src="../../.gitbook/assets/screenshot-discover-detail.png" alt=""><figcaption><p>Panneau de détail d'un lead (vue scindée)</p></figcaption></figure>
 
@@ -55,7 +57,7 @@ Votre pipeline : leads importés depuis un fichier, exportés depuis Discover ou
 
 <figure><img src="../../.gitbook/assets/screenshot-monitor-tab.png" alt=""><figcaption><p>Onglet Monitor</p></figcaption></figure>
 
-**Colonnes :** Nom, Description, Statut, Localisation, Taille, Complétude des données.
+**Colonnes :** Nom, Description, Statut, Localisation, Taille, Contact recommandé, Dernière action, Données, Actions.
 
 **Statuts des leads :**
 
@@ -66,11 +68,24 @@ Votre pipeline : leads importés depuis un fichier, exportés depuis Discover ou
 | WON | Affaire conclue |
 | LOST | Affaire perdue |
 
-**Actions principales :**
+### Filtres
 
-- Cliquer sur un lead pour ouvrir sa fiche et modifier son statut
-- Utiliser les filtres (via les Lenses) pour se concentrer sur des segments précis
-- Exporter des leads en CSV
+Cliquez sur l'icône filtre en haut à droite pour ouvrir le popover. Les filtres sont de style Notion : des lignes empilées **[champ] [opérateur] [valeur]** combinées en AND, plus deux toggles en haut du popover.
+
+| Contrôle | Ce qu'il fait |
+|----------|--------------|
+| **Uniquement les leads aimés** | Limite Monitor aux leads que vous avez likés |
+| **Inclure les leads provenant de l'organisation** | Affiche les leads avec lesquels vos coéquipiers ont interagi, en plus des vôtres — pour une vue pipeline org-wide complète |
+| **+ Ajouter un filtre** | Ajoute une ligne [champ] [opérateur] [valeur]. Le sélecteur de champs est groupé en champs standards (Localisation, Secteur, Taille, Dernière action, Date de dernière action) et champs personnalisés CRM |
+| **Réinitialiser** | Efface tous les filtres d'un coup |
+
+Les valeurs texte des champs personnalisés s'auto-complètent depuis vos données au fil de la saisie.
+
+### Autres actions
+
+- Cliquez sur un lead pour ouvrir sa fiche et modifier son statut
+- Basculez entre les vues **Liste**, **Scindée**, **Carte** et **Dashboard** via le toggle de mode de vue
+- Exportez des leads en CSV
 
 {% hint style="info" %}
 Les leads exportés depuis Discover apparaissent ici automatiquement. C'est pourquoi ils « disparaissent » de Discover : ils ont intégré votre pipeline.
@@ -84,9 +99,9 @@ Votre espace de prospection quotidien. Affiche les leads likés prêts à être 
 
 <figure><img src="../../.gitbook/assets/screenshot-activate-tab.png" alt=""><figcaption><p>Onglet Activate</p></figcaption></figure>
 
-**Colonnes :** Actions du jour, Nom, Description, Localisation, Source, Prochaine étape, Statut, Dernière action.
+**Colonnes :** Actions du jour, Nom, Description, Localisation, Source, Prochaine étape, Contact recommandé, Statut, Dernière action.
 
-**Classifications des leads :**
+**Classifications des leads** (menu déroulant en haut à droite) :
 
 - **Activatable** : leads prêts pour la prise de contact
 - **On hold** : leads en pause

--- a/fr/product-guides/lead-profile.md
+++ b/fr/product-guides/lead-profile.md
@@ -4,6 +4,8 @@ Cliquez sur le nom d'un lead pour ouvrir sa fiche. C'est votre vue centrale pour
 
 <figure><img src="../../.gitbook/assets/screenshot-lead-profile.png" alt=""><figcaption><p>Fiche lead</p></figcaption></figure>
 
+La fiche est organisée de haut en bas dans l'ordre où vous avez généralement besoin de l'information : identité → à qui parler → opinion de l'IA → qualification → accordéons détaillés.
+
 ---
 
 ## En-tête
@@ -12,10 +14,46 @@ En haut de chaque fiche, vous trouverez :
 
 - **Nom de l'entreprise** et logo
 - **Tags** : localisation, effectifs, secteur
-- **Description courte** (générée par l'IA à partir de données publiques)
-- **Score** (0–99) : degré de correspondance avec vos leads likés et affaires gagnées. Plus c'est élevé, mieux c'est.
+- **Description courte** (générée par l'IA à partir de données publiques) — cliquez sur **Read more** pour la version complète
+
+---
+
+## Contacts recommandés & épinglés
+
+Juste sous l'en-tête, vous verrez soit :
+
+- Un **contact recommandé** — sélectionné automatiquement par Leadbay en fonction de votre persona cible
+- Soit un ou plusieurs **contacts épinglés** — des contacts que vous (ou un coéquipier) avez explicitement choisi de garder en haut
+
+Cliquez sur l'icône pin de n'importe quelle carte contact org pour l'épingler. Épingler échange le contact recommandé pour votre (vos) sélection(s) épinglée(s). Désépinglez-les tous et le recommandé réapparaît. Les pins sont au niveau de l'organisation, donc le reste de votre équipe voit la même priorisation.
+
+Chaque carte de contact épinglé/recommandé est condensée — le poste apparaît à côté du nom — et affiche téléphone, email et LinkedIn d'un coup d'œil.
+
+---
+
+## Requalify
+
+Cliquez sur **Requalify** pour récupérer des données actualisées depuis le site web de l'entreprise et relancer l'évaluation IA :
+
+- **Profil entreprise** : activités, produits, services, effectifs, marché cible
+- **Personnes clés et organisation** : décideurs et organigramme
+- **Technologies et innovation** : outils et logiciels utilisés
+
+Les résultats sont mis en cache — vous pouvez requalifier à tout moment pour obtenir une évaluation à jour basée sur les dernières données du site web.
+
+---
+
+## Score, Statut & Likes
+
+- **Score** (0–99) : degré de correspondance avec vos leads likés et affaires gagnées. Le petit badge à côté affiche la contribution **boost** de l'IA (positif / neutre / négatif).
 - **Statut** : cliquez pour modifier (NO STATUS, WANTED, WON, LOST)
 - Boutons **Like / Dislike**
+
+---
+
+## Tags d'intention
+
+Tags colorés courts qui résument pourquoi Leadbay a remonté cette entreprise (ex. « Fragmented SMB Market », « Hiring sales »). Ils reflètent les signaux que l'IA a fait remonter lors de la qualification.
 
 ---
 
@@ -34,7 +72,27 @@ Ces actions apparaissent dans l'onglet Activate et sont suivies dans le Dashboar
 
 ---
 
-## Onglets
+## Résumé IA et qualification
+
+Si l'[AI Assistant](ai-assistant.md) est configuré :
+
+- Un **résumé IA** avec contexte et prédictions
+- Des **réponses de qualification** : 🟢 positif, 🔘 neutre, 🔴 négatif
+- Des **prochaines étapes suggérées** et angles d'approche recommandés
+
+Tout cela vous aide à préparer votre prise de contact sans recherche manuelle.
+
+### Raisonnement IA
+
+Lors de la qualification d'un lead, l'IA peut afficher son raisonnement. Vous pouvez suivre pas à pas comment le modèle interprète les données publiques, les web insights et vos questions de qualification pour aboutir à son évaluation. Cette transparence vous aide à comprendre — et à faire confiance — aux recommandations de l'IA.
+
+<figure><img src="../../.gitbook/assets/screenshot-stream-of-consciousness.png" alt="Raisonnement de qualification IA"><figcaption><p>Le raisonnement de l'IA, visible dans la fiche lead</p></figcaption></figure>
+
+---
+
+## Sections en accordéon
+
+Plus bas, des sections dépliables contiennent tout le reste :
 
 ### Entreprise
 
@@ -67,33 +125,3 @@ Chronologie de toutes les interactions : changements de statut, likes, enrichiss
 ### Filiales
 
 Entités liées et filiales au sein du même groupe. Utile pour étendre votre prospection au sein d'une structure de groupe.
-
----
-
-## Requalify
-
-Cliquez sur **Requalify** pour récupérer des données actualisées depuis le site web de l'entreprise et relancer l'évaluation IA :
-
-- **Profil entreprise** : activités, produits, services, effectifs, marché cible
-- **Personnes clés et organisation** : décideurs et organigramme
-- **Technologies et innovation** : outils et logiciels utilisés
-
-Les résultats sont mis en cache — vous pouvez requalifier à tout moment pour obtenir une évaluation à jour basée sur les dernières données du site web.
-
----
-
-## Résumé IA et qualification
-
-Si l'[AI Assistant](ai-assistant.md) est configuré :
-
-- Un **résumé IA** avec contexte et prédictions
-- Des **réponses de qualification** : 🟢 positif, 🔘 neutre, 🔴 négatif
-- Des **prochaines étapes suggérées** et angles d'approche recommandés
-
-Tout cela vous aide à préparer votre prise de contact sans recherche manuelle.
-
-### Raisonnement IA
-
-Lors de la qualification d'un lead, l'IA peut afficher son raisonnement. Vous pouvez suivre pas à pas comment le modèle interprète les données publiques, les web insights et vos questions de qualification pour aboutir à son évaluation. Cette transparence vous aide à comprendre — et à faire confiance — aux recommandations de l'IA.
-
-<figure><img src="../../.gitbook/assets/screenshot-stream-of-consciousness.png" alt="Raisonnement de qualification IA"><figcaption><p>Le raisonnement de l'IA, visible dans la fiche lead</p></figcaption></figure>

--- a/fr/product-guides/leadbay-mcp.md
+++ b/fr/product-guides/leadbay-mcp.md
@@ -1,0 +1,123 @@
+# Leadbay MCP pour Claude
+
+Donnez à Claude (Desktop, Code et Cowork) un accès direct à votre compte Leadbay. Une fois installé, Claude peut récupérer des leads, les qualifier, enrichir des contacts, journaliser les actions de prospection — en utilisant vos vraies données, avec vos permissions.
+
+Ce guide couvre l'installation dans **Claude Cowork** via l'extension prête à l'emploi `.mcpb`. Les autres clients (Claude Desktop, Cursor, Claude Code) sont couverts dans le [README Leadbay MCP](https://github.com/leadbay/leadclaw#install).
+
+{% hint style="info" %}
+Le serveur MCP est open source et se trouve sur [github.com/leadbay/leadclaw](https://github.com/leadbay/leadclaw). Il utilise **votre** compte Leadbay, donc toute action prise par Claude est équivalente à ce que vous auriez fait vous-même dans l'application.
+{% endhint %}
+
+---
+
+## Ce dont vous avez besoin
+
+- Un compte Leadbay ([inscrivez-vous ici](https://leadbay.ai/) si vous n'en avez pas)
+- Claude Cowork (ou tout client Claude qui supporte les extensions MCP)
+- Deux minutes
+
+---
+
+## Étape 1 — Télécharger la dernière extension
+
+Ouvrez la [page des releases LeadClaw](https://github.com/leadbay/leadclaw/releases/) et récupérez le dernier fichier `.mcpb` (cherchez un nom du type `leadbay-X.Y.Z.mcpb` dans la section **Assets** de la release la plus récente).
+
+Sauvegardez-le dans un endroit facile à retrouver — votre dossier Téléchargements fonctionne.
+
+---
+
+## Étape 2 — Générer un bearer token Leadbay
+
+L'extension a besoin d'un token pour parler à Leadbay en votre nom.
+
+1. Ouvrez un terminal
+2. Lancez :
+
+   ```bash
+   npx -y @leadbay/mcp@latest login --email vous@votreentreprise.com --region fr
+   ```
+
+   - Remplacez `vous@votreentreprise.com` par votre email de connexion Leadbay
+   - Utilisez `--region fr` si vous vous êtes inscrit sur l'instance française, `--region us` pour l'instance US
+
+3. Votre mot de passe vous sera demandé (utilisé une seule fois pour s'authentifier, puis jeté)
+4. La CLI imprime un **bearer token** (commence par `u.`). Copiez-le — vous le collerez à l'étape 4
+
+{% hint style="warning" %}
+Traitez le token comme un mot de passe. Quiconque a ce token peut agir sur votre compte Leadbay.
+{% endhint %}
+
+---
+
+## Étape 3 — Installer l'extension dans Cowork
+
+Dans Claude Cowork, allez dans :
+
+**Settings → Extensions → Advanced → Install extension**
+
+Sélectionnez le fichier `leadbay-X.Y.Z.mcpb` que vous avez téléchargé à l'étape 1.
+
+Un dialogue s'ouvre avec les détails de l'extension. Cliquez sur **Install**, puis confirmez avec **Install** à nouveau.
+
+Une fois installée, basculez l'extension sur **Enabled**.
+
+---
+
+## Étape 4 — Configurer le token
+
+Toujours dans **Settings → Extensions**, trouvez Leadbay dans la liste et cliquez sur **Configure**.
+
+- Collez votre bearer token dans le champ `LEADBAY_TOKEN`
+- Définissez le champ `LEADBAY_REGION` pour correspondre à celui utilisé lors du login (`us` ou `fr`)
+- Sauvegardez
+
+---
+
+## Étape 5 — Autoriser les outils
+
+Leadbay livre deux saveurs d'outils :
+
+| Saveur | Ce qu'elle contient | Permission recommandée |
+|--------|---------------------|------------------------|
+| **Read-only** | Récupère leads, lenses, profils, contacts, taste profile, quota d'enrichissement — ne change jamais rien | **Always allow** |
+| **Write / delete** | Qualifie des leads, enrichit des contacts, ajoute des notes, importe des leads, journalise des actions de prospection, affine l'audience | **Always allow** |
+
+Les deux saveurs peuvent être en always-allow sans risque car le Leadbay MCP est **scopé à votre compte** — rien de destructif au niveau plateforme. Mettre les deux en « always allow » permet à Claude de circuler sans vous interrompre pour une permission à chaque appel.
+
+Pour configurer : dans l'écran **Configure** de l'extension Leadbay, mettez **Always allow** à la fois pour le groupe d'outils read-only et pour le groupe write/delete.
+
+---
+
+## Essayez-le
+
+Ouvrez une conversation Cowork et demandez :
+
+> *Récupère les meilleurs leads du jour et dis-moi lesquels ouvrir en priorité ce matin.*
+
+Claude appellera `leadbay_pull_leads`, `leadbay_get_lead_profile` et leurs amis — et répondra avec une shortlist courte et qualifiée.
+
+Quelques prompts supplémentaires qui marchent dès le départ :
+
+- *Recherche acme.com — est-ce que c'est un fit pour nous ?*
+- *Affine mon audience pour me focaliser sur les entreprises européennes qui recrutent des commerciaux.*
+- *Je viens d'envoyer un email à Jane chez Acme. Journalise-le comme action de prospection.*
+
+La liste complète des outils et des workflows recommandés est dans le [README LeadClaw](https://github.com/leadbay/leadclaw#tools).
+
+---
+
+## Mettre à jour
+
+Quand une nouvelle release sort, répétez l'**étape 1** (téléchargez le nouveau `.mcpb`) et l'**étape 3** (Install extension). Cowork remplace l'ancienne version en place ; votre token et vos permissions restent configurés.
+
+---
+
+## Dépannage
+
+| Symptôme | Solution |
+|----------|----------|
+| Claude dit « non authentifié » ou erreurs 401 | Le token a peut-être expiré. Refaites l'**étape 2** pour en générer un nouveau et collez-le dans **Configure** |
+| Les outils n'apparaissent pas dans Cowork | Vérifiez que l'extension est bien sur **Enabled** dans Settings → Extensions |
+| Les outils apparaissent mais Claude ne les appelle pas | Ouvrez **Configure** et passez les groupes d'outils en **Always allow** |
+| Mauvaise région (pas de leads / 404s) | Confirmez que `LEADBAY_REGION` correspond à l'endroit où vous vous êtes inscrit (`us` vs `fr`) |
+| Autre problème | Ouvrez un bug sur [github.com/leadbay/leadclaw/issues](https://github.com/leadbay/leadclaw/issues) |

--- a/fr/product-guides/team-management.md
+++ b/fr/product-guides/team-management.md
@@ -16,7 +16,7 @@ Vous pouvez consulter et modifier le **nom de votre organisation**.
 
 ## Membres de l'équipe
 
-La section Équipe affiche tous les membres avec les informations suivantes :
+La section Membres affiche tous les membres et un compteur de sièges (ex. *« 100,000 seats available including 0 managers »*). Chaque ligne contient :
 
 | Colonne | Description |
 |---------|-------------|
@@ -24,19 +24,27 @@ La section Équipe affiche tous les membres avec les informations suivantes :
 | **Email** | Email de connexion |
 | **Verified** | Si l'utilisateur a confirmé son email |
 | **Role** | Admin ou Member |
+| **Manager** | Le manager de l'utilisateur (défini lors de l'invitation ou de la modification d'un membre) |
 
 ### Ajouter des membres
 
-Cliquez sur **+ Add new member** pour inviter quelqu'un par email. La personne recevra une invitation à rejoindre votre organisation.
+Cliquez sur **+ Add new member** pour inviter quelqu'un par email. Le dialogue demande :
+
+1. Un **Email**
+2. Un **Role** — `Admin` ou `Member` (avec une description d'une ligne de ce que chacun peut faire)
+3. Si vous choisissez `Member`, un menu déroulant **Manager (optional)** pour lui assigner son manager depuis les membres existants
+
+L'invité reçoit une invitation par email à rejoindre votre organisation.
 
 ### Rôles
 
 | Rôle | Capacités |
 |------|-----------|
 | **Admin** | Accès complet : gestion équipe, paramètres, sources de données, facturation, lenses |
-| **Member** | Utilisation de Leadbay : discover, like, enrichir, exporter, activer. Pas d'accès aux paramètres ni à la facturation |
+| **Member** | Utilisation de Leadbay : discover, like, enrichir, exporter, activate. Pas d'accès aux paramètres ni à la facturation |
+| **Manager** | Un Member qui est le manager d'un ou plusieurs autres membres. Obtient la visibilité sur l'activité de ses subordonnés dans le [Dashboard Manager](manager-dashboard.md). Ne modifie pas les permissions applicatives — change seulement qui apparaît sous qui |
 
-Utilisez le menu d'actions (trois points) sur chaque ligne pour modifier le rôle d'un membre ou le retirer.
+Utilisez le menu d'actions (trois points) sur chaque ligne pour modifier le rôle d'un membre, définir/modifier son manager, ou le retirer.
 
 {% hint style="info" %}
 Seuls les admins peuvent importer des données, gérer la facturation et modifier les paramètres de l'organisation.

--- a/news/changelog.md
+++ b/news/changelog.md
@@ -4,6 +4,17 @@ Leadbay ships updates every week. Below are the major milestones.
 
 ---
 
+## May 2026
+
+- **Pinned contacts on the lead profile**: pin the contacts that matter for your outreach to the top of the profile. The recommended contact slot still shows automatically when nothing is pinned; pin one and it takes its place. Several contacts can be pinned at once. Pins are org-level, so your team sees the same prioritization.
+- **Notion-style filters in Monitor**: a focused filter popover at the top-right of Monitor. Add as many filters as you need with [field] [operator] [value] rows, joined with AND. Field picker is grouped into standard fields (Location, Sector, Size, Last action, Last action date) and CRM custom fields. Custom-field text values auto-complete from your data.
+- **Organization-wide Monitor view**: a new **Include leads from organization** toggle at the top of the Monitor filter popover surfaces leads your teammates interacted with — alongside your own — for a complete pipeline view. Pair it with **Only liked leads** to keep things focused.
+- **Manager role**: when inviting a member, you can now mark them as a **Manager** so they get visibility into their team's activity in the Manager Dashboard. The members table has a new **Manager** column to show who covers whom. The seats counter on the Organization page also reports how many are managers.
+- **Logout — this device or all devices**: clicking **Logout** now opens a dialog asking whether you want to sign out of just this session or every device and agent/API token session at once.
+- **Salesforce integration**: a new Salesforce option appears in the integrations picker alongside Zapier and SFTP — connect your CRM data directly.
+- **Refined final-score display**: the score breakdown on lead profiles has been tightened — easier to read at a glance.
+- **Leadbay MCP server**: a brand-new **Model Context Protocol** server lets Claude (Desktop, Code, Cowork) pull leads, qualify them, enrich contacts, and log outreach on your behalf — using your Leadbay account. See [Leadbay MCP](../product-guides/leadbay-mcp.md) for the install walkthrough.
+
 ## April 2026
 
 - **SFTP connector**: connect an SFTP server to automatically sync a CSV file with your leads. Leadbay detects changes and re-imports only when the file is updated. Admin only.
@@ -13,6 +24,7 @@ Leadbay ships updates every week. Below are the major milestones.
 - **Global search**: press ⌘K (Mac) or Ctrl+K to search for leads across Discover, Monitor, and Activate. Suggestions appear as you type.
 
 <figure><img src="../.gitbook/assets/screenshot-search.png" alt="Global search with suggestions"><figcaption><p>Search for leads by name — suggestions appear as you type</p></figcaption></figure>
+
 - **Failed enrichment tracking**: contact cards now show which enrichment channels failed, with retry options and failure date tooltips. Previously failed contacts can be skipped during bulk enrichment.
 - **Custom fields management**: admins can now add and edit custom fields directly from Data Sources settings.
 

--- a/overview/best-practice-guides/leadbay-for-sales-reps.md
+++ b/overview/best-practice-guides/leadbay-for-sales-reps.md
@@ -90,7 +90,7 @@ This is your playground:
 
 * open a lead’s profile
 * ask the AI to help you qualify it
-* launch a web search
+* launch a web search (Requalify)
 * draft your first message or prep your call
 
 💡 **Leadbay tip:** the chat AI helps you move seamlessly from “discovery” to “contact” with highly contextual insights.

--- a/product-guides/discover-monitor-activate.md
+++ b/product-guides/discover-monitor-activate.md
@@ -31,6 +31,7 @@ AI-recommended leads based on your ICP (Ideal Customer Profile), past wins, and 
 | Description | Short AI-generated summary |
 | Location | City / region |
 | Size | Employee count range |
+| Recommended contact | The best contact Leadbay knows about — click to enrich |
 | Data | Data completeness indicator |
 
 **Key actions:**
@@ -38,6 +39,7 @@ AI-recommended leads based on your ICP (Ideal Customer Profile), past wins, and 
 - **Like** (thumbs up): tells the model "show me more like this." The lead moves to Activate.
 - **Dislike** (thumbs down): tells the model "not relevant." The lead is removed from Discover.
 - **Click a lead** to open its profile for details before deciding.
+- **Select leads** with the checkbox column, then use the floating action bar to **Qualify**, **Enrich**, or **Export**.
 
 <figure><img src="../.gitbook/assets/screenshot-discover-detail.png" alt=""><figcaption><p>Lead detail panel (split view)</p></figcaption></figure>
 
@@ -55,7 +57,7 @@ Your pipeline: leads imported from a file, exported from Discover, or synced via
 
 <figure><img src="../.gitbook/assets/screenshot-monitor-tab.png" alt=""><figcaption><p>Monitor tab</p></figcaption></figure>
 
-**Columns:** Name, Description, Status, Location, Size, Data completeness.
+**Columns:** Name, Description, Status, Location, Size, Recommended contact, Last action, Data, Actions.
 
 **Lead statuses:**
 
@@ -66,10 +68,23 @@ Your pipeline: leads imported from a file, exported from Discover, or synced via
 | WON | Deal closed successfully |
 | LOST | Deal lost |
 
-**Key actions:**
+### Filters
+
+Click the filter icon in the top-right toolbar to open the filter popover. Filters are Notion-style: stacked rows of **[field] [operator] [value]** joined with AND, plus two top-of-popover toggles.
+
+| Control | What it does |
+|---------|--------------|
+| **Only liked leads** | Restrict Monitor to leads you've liked |
+| **Include leads from organization** | Show leads your teammates interacted with, alongside your own — for a complete org-wide pipeline view |
+| **+ Add filter** | Add a [field] [operator] [value] row. Field picker is grouped into standard fields (Location, Sector, Size, Last action, Last action date) and CRM custom fields |
+| **Reset all** | Clear every filter at once |
+
+Custom-field text values auto-complete from your data as you type.
+
+### Other actions
 
 - Click a lead to open its profile and update its status
-- Use filters (via Lenses) to focus on specific segments
+- Switch between **List**, **Split**, **Map**, and **Dashboard** views using the view-mode toggle
 - Export leads to CSV
 
 {% hint style="info" %}
@@ -84,9 +99,9 @@ Your daily prospecting workspace. Shows liked leads ready for action, ranked by 
 
 <figure><img src="../.gitbook/assets/screenshot-activate-tab.png" alt=""><figcaption><p>Activate tab</p></figcaption></figure>
 
-**Columns:** Today's actions, Name, Description, Location, Source, Next step, Status, Last action.
+**Columns:** Today's actions, Name, Description, Location, Source, Next step, Recommended contact, Status, Last action.
 
-**Lead classifications:**
+**Lead classifications** (filter dropdown at the top-right):
 
 - **Activatable**: leads ready for outreach
 - **On hold**: paused leads

--- a/product-guides/lead-profile.md
+++ b/product-guides/lead-profile.md
@@ -4,6 +4,8 @@ Click any lead name to open its profile. The profile is your central view for un
 
 <figure><img src="../.gitbook/assets/screenshot-lead-profile.png" alt=""><figcaption><p>Lead profile</p></figcaption></figure>
 
+The profile is organized top-to-bottom in the order you typically need information: identity → who to talk to → AI take → qualification → deeper accordions.
+
 ---
 
 ## Header
@@ -12,10 +14,46 @@ At the top of every profile you'll find:
 
 - **Company name** and logo
 - **Tags**: location, employee size, sector
-- **Short description** (AI-generated from public data)
-- **Score** (0–99): how closely this lead matches your liked leads and won deals. Higher is better.
+- **Short description** (AI-generated from public data) — click **Read more** for the full version
+
+---
+
+## Recommended & Pinned Contacts
+
+Right under the header, you'll see either:
+
+- A **Recommended contact** — automatically selected by Leadbay based on your target persona
+- Or one or more **Pinned contacts** — contacts you (or a teammate) have explicitly chosen to keep at the top
+
+Click the pin icon on any org contact card to pin it. Pinning swaps the recommended contact for your pinned selection(s). Unpin them all and the recommended one re-appears. Pins are organization-level, so the rest of your team sees the same prioritization.
+
+Each pinned/recommended contact card is condensed — job title sits next to the name — and shows the phone, email, and LinkedIn at a glance.
+
+---
+
+## Requalify
+
+Click **Requalify** to pull fresh data from the company's website and re-run the full AI assessment:
+
+- **Company profile**: activities, products, services, employee count, target market
+- **Key people & organization**: decision-makers and org structure
+- **Technologies & Innovation**: tools and software the company uses
+
+Results are cached — you can requalify anytime for an updated assessment based on the latest website data.
+
+---
+
+## Score, Status & Likes
+
+- **Score** (0–99): how closely this lead matches your liked leads and won deals. The small badge next to it shows the AI **boost** contribution (positive / neutral / negative).
 - **Status**: click to change (NO STATUS, WANTED, WON, LOST)
 - **Like / Dislike** buttons
+
+---
+
+## Intent Tags
+
+Short colored tags that summarize why Leadbay flagged this company (e.g. "Fragmented SMB Market", "Hiring sales"). They reflect signals the AI surfaced while qualifying.
 
 ---
 
@@ -34,7 +72,27 @@ These actions appear in the Activate tab and are tracked in the Manager Dashboar
 
 ---
 
-## Tabs
+## AI Summary & Qualification
+
+If the [AI Assistant](ai-assistant.md) is configured:
+
+- An **AI summary** appears with context and predictions
+- **Qualification answers** show as indicators: 🟢 positive, 🔘 neutral, 🔴 negative
+- **Predicted next steps** and recommended approach angles
+
+These help you prepare before reaching out, without manual research.
+
+### AI Reasoning
+
+When the AI qualifies a lead, it can display its reasoning process. You can read step-by-step how the model interprets public data, web insights, and your qualification questions to reach its assessment. This transparency helps you understand — and trust — the AI's recommendations.
+
+<figure><img src="../.gitbook/assets/screenshot-stream-of-consciousness.png" alt="AI qualification reasoning"><figcaption><p>The AI's reasoning, visible in the lead profile</p></figcaption></figure>
+
+---
+
+## Accordion Sections
+
+Further down, expandable sections hold everything else:
 
 ### Company
 
@@ -67,33 +125,3 @@ Timeline of all interactions: status changes, likes, enrichments, exports. Helps
 ### Subsidiaries
 
 Shows related entities and child companies within the same corporate group. Useful for expanding prospecting within a group structure.
-
----
-
-## Requalify
-
-Click **Requalify** to pull fresh data from the company's website and re-run the AI assessment:
-
-- **Company profile**: activities, products, services, employee count, target market
-- **Key people & organization**: decision-makers and org structure
-- **Technologies & Innovation**: tools and software the company uses
-
-Results are cached — you can requalify anytime for an updated assessment based on the latest website data.
-
----
-
-## AI Summary & Qualification
-
-If the [AI Assistant](ai-assistant.md) is configured:
-
-- An **AI summary** appears with context and predictions
-- **Qualification answers** show as indicators: 🟢 positive, 🔘 neutral, 🔴 negative
-- **Predicted next steps** and recommended approach angles
-
-These help you prepare before reaching out, without manual research.
-
-### AI Reasoning
-
-When the AI qualifies a lead, it can display its reasoning process. You can read step-by-step how the model interprets public data, web insights, and your qualification questions to reach its assessment. This transparency helps you understand — and trust — the AI's recommendations.
-
-<figure><img src="../.gitbook/assets/screenshot-stream-of-consciousness.png" alt="AI qualification reasoning"><figcaption><p>The AI's reasoning, visible in the lead profile</p></figcaption></figure>

--- a/product-guides/leadbay-mcp.md
+++ b/product-guides/leadbay-mcp.md
@@ -1,0 +1,123 @@
+# Leadbay MCP for Claude
+
+Give Claude (Desktop, Code, and Cowork) direct access to your Leadbay account. Once installed, Claude can pull leads, qualify them, enrich contacts, log outreach — all using your real data, with your permissions.
+
+This guide covers installation in **Claude Cowork** via the prebuilt `.mcpb` extension. Other clients (Claude Desktop, Cursor, Claude Code) are covered in the [Leadbay MCP README](https://github.com/leadbay/leadclaw#install).
+
+{% hint style="info" %}
+The MCP server is open source and lives at [github.com/leadbay/leadclaw](https://github.com/leadbay/leadclaw). It uses **your** Leadbay account, so any action Claude takes is the same as if you'd done it yourself in the app.
+{% endhint %}
+
+---
+
+## What you'll need
+
+- A Leadbay account ([sign up here](https://leadbay.ai/) if you don't have one)
+- Claude Cowork (or any Claude client that supports MCP extensions)
+- Two minutes
+
+---
+
+## Step 1 — Download the latest extension
+
+Open the [LeadClaw releases page](https://github.com/leadbay/leadclaw/releases/) and grab the latest `.mcpb` file (look for a name like `leadbay-X.Y.Z.mcpb` under the most recent release's **Assets**).
+
+Save it somewhere easy to find — your Downloads folder works.
+
+---
+
+## Step 2 — Mint a Leadbay bearer token
+
+The extension needs a token to talk to Leadbay on your behalf.
+
+1. Open a terminal
+2. Run:
+
+   ```bash
+   npx -y @leadbay/mcp@latest login --email you@yourcompany.com --region us
+   ```
+
+   - Replace `you@yourcompany.com` with your Leadbay login email
+   - Use `--region us` if you signed up on the US instance, `--region fr` for the French instance
+
+3. You'll be prompted for your password (it's used once to authenticate, then discarded)
+4. The CLI prints a **bearer token** (starts with `u.`). Copy it — you'll paste it in Step 4
+
+{% hint style="warning" %}
+Treat the token like a password. Anyone with this token can act on your Leadbay account.
+{% endhint %}
+
+---
+
+## Step 3 — Install the extension in Cowork
+
+In Claude Cowork, go to:
+
+**Settings → Extensions → Advanced → Install extension**
+
+Pick the `leadbay-X.Y.Z.mcpb` file you downloaded in Step 1.
+
+A dialog opens with the extension details. Click **Install**, then confirm with **Install** again.
+
+Once installed, toggle the extension to **Enabled**.
+
+---
+
+## Step 4 — Configure the token
+
+Still in **Settings → Extensions**, find Leadbay in the list and click **Configure**.
+
+- Paste your bearer token in the `LEADBAY_TOKEN` field
+- Set the `LEADBAY_REGION` field to match the one you used at login (`us` or `fr`)
+- Save
+
+---
+
+## Step 5 — Allow the tools
+
+Leadbay ships two flavors of tools:
+
+| Flavor | What's in it | Recommended permission |
+|--------|--------------|------------------------|
+| **Read-only** | Pulls leads, lenses, profiles, contacts, taste profile, enrichment quota — never changes anything | **Always allow** |
+| **Write / delete** | Qualifies leads, enriches contacts, adds notes, imports leads, reports outreach, refines audience | **Always allow** |
+
+Both flavors are safe to always-allow because the Leadbay MCP is **scoped to your account** — there's nothing destructive at the platform level. Setting both to "always allow" makes Claude flow without interrupting you for permission on every call.
+
+To configure: in the Leadbay extension's **Configure** screen, set **Always allow** for both the read-only tool group and the write/delete tool group.
+
+---
+
+## Try it
+
+Open a Cowork conversation and ask:
+
+> *Pull today's top leads and tell me which two are worth opening this morning.*
+
+Claude will call `leadbay_pull_leads`, `leadbay_get_lead_profile`, and friends — and reply with a short, qualified shortlist.
+
+A few more prompts that work out of the box:
+
+- *Research acme.com — is it a fit for us?*
+- *Refine my audience to focus on EU companies hiring sales reps.*
+- *I just emailed Jane at Acme. Log it as outreach.*
+
+The full list of tools and recommended workflows is in the [LeadClaw README](https://github.com/leadbay/leadclaw#tools).
+
+---
+
+## Updating
+
+When a new release ships, repeat **Step 1** (download the new `.mcpb`) and **Step 3** (Install extension). Cowork replaces the old version in place; your token and permissions stay configured.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Claude says "not authenticated" or 401 errors | The token may have expired. Repeat **Step 2** to mint a fresh one and paste it in **Configure** |
+| Tools don't appear in Cowork | Make sure the extension toggle is **Enabled** in Settings → Extensions |
+| Tools appear but Claude won't call them | Open **Configure** and switch the tool groups to **Always allow** |
+| Wrong region (no leads / 404s) | Confirm `LEADBAY_REGION` matches where you signed up (`us` vs `fr`) |
+| Other issue | File a bug at [github.com/leadbay/leadclaw/issues](https://github.com/leadbay/leadclaw/issues) |

--- a/product-guides/team-management.md
+++ b/product-guides/team-management.md
@@ -18,7 +18,7 @@ Here you can:
 
 ## Team Members
 
-The Team section shows all members with their:
+The Members section shows all members and a seats counter (e.g. *"100,000 seats available including 0 managers"*). Each row contains:
 
 | Column | Description |
 |--------|-------------|
@@ -26,10 +26,17 @@ The Team section shows all members with their:
 | **Email** | Login email |
 | **Verified** | Whether the user confirmed their email |
 | **Role** | Admin or Member |
+| **Manager** | The user's manager (set when inviting or editing a member) |
 
 ### Adding Members
 
-Click **+ Add new member** to invite someone by email. They'll receive an invitation to join your organization.
+Click **+ Add new member** to invite someone by email. The dialog asks for:
+
+1. **Email**
+2. A **Role** — `Admin` or `Member` (with a one-line description of what each can do)
+3. If you pick `Member`, an optional **Manager** dropdown to assign their manager from existing members
+
+The invitee receives an email invitation to join your organization.
 
 ### Roles
 
@@ -37,8 +44,9 @@ Click **+ Add new member** to invite someone by email. They'll receive an invita
 |------|-------------|
 | **Admin** | Full access: manage team, organization settings, data sources, billing, lenses |
 | **Member** | Use Leadbay: discover, like, enrich, export, activate. Cannot manage org settings or billing |
+| **Manager** | A Member who is the manager of one or more other members. Gets visibility into their reports' activity in the [Manager Dashboard](manager-dashboard.md). Doesn't change app permissions — only changes who shows up under whom |
 
-Use the action menu (three dots) on each row to change a member's role or remove them.
+Use the action menu (three dots) on each row to change a member's role, set/change their manager, or remove them.
 
 {% hint style="info" %}
 Only admins can import data, manage billing, and change organization settings.


### PR DESCRIPTION
## Summary

- Adds May 2026 changelog entries verified live on leadbay.app: pinned contacts, Notion-style Monitor filters with org-wide toggle, Manager role + Manager column, logout-this-device-or-all dialog, Salesforce integration, refined final-score display, and the new Leadbay MCP server.
- Adds a new **Leadbay MCP for Claude** guide (EN + FR) covering the `.mcpb` install flow in Claude Cowork — download from GitHub releases, mint a bearer token via \`npx @leadbay/mcp login\`, install via Settings → Extensions → Advanced, configure region + token, set Always Allow on the read-only and write tool groups, plus troubleshooting and the update flow.
- Restructures the Lead Profile guide for the new top-to-bottom order: identity → pinned/recommended contact swap → Requalify → score with boost badge → intent tags → AI summary → accordion sections.
- Updates Team & Organization to document the new Manager column, the seats counter (`"…dont N manager"`), and the `Manager (optional)` dropdown in the invite dialog.
- Adds the new Monitor filter popover (field + custom-field picker, **Only liked leads** and **Include leads from organization** toggles) to the Discover/Monitor/Activate guide, and notes the new **Recommended contact** column in Discover.

## Test plan

- [ ] Render the GitBook preview and verify SUMMARY / FR SUMMARY entries point at `leadbay-mcp.md` correctly.
- [ ] Verify cross-links resolve: `leadbay-mcp.md` ↔ README quick links, lead-profile ↔ Activate tab reference, team-management ↔ manager-dashboard.
- [ ] Spot-check each May 2026 changelog item against the live app on leadbay.app while logged in.
- [ ] Follow-up: refresh `.gitbook/assets/screenshot-*.png` for Discover, Monitor (with the new filter popover open), lead profile (showing pinned contact + Requalify + boost badge), and Team & Organization (showing the Manager column + seats counter) — kept as-is in this PR because the agent's browser sandbox couldn't save captures to disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)