### PR TITLE
Document Claude Desktop MCP load delay in Leadbay MCP guide

### DIFF
--- a/fr/product-guides/leadbay-mcp.md
+++ b/fr/product-guides/leadbay-mcp.md
@@ -112,6 +112,16 @@ Quand une nouvelle release sort, répétez l'**étape 1** (téléchargez le nouv
 
 ---
 
+## Utiliser Leadbay avec Claude Desktop
+
+Claude Desktop est plus lent que Cowork à charger les outils MCP, donc quelques précautions supplémentaires aident.
+
+Après avoir installé l'extension Leadbay, **quittez complètement Claude Desktop et relancez-le** (Cmd-Q sur Mac, puis rouvrez — ne vous contentez pas de fermer la fenêtre). Ouvrez un nouveau chat et attendez environ **30 secondes** avant d'envoyer votre premier message. Cela laisse à Claude le temps de charger les outils Leadbay.
+
+Si votre premier message reçoit une réponse du genre *« Je ne vois pas d'outils Leadbay »* ou *« Je ne trouve pas Leadbay dans votre configuration »*, pas d'inquiétude — les outils sont encore en train de se charger. Envoyez n'importe quel deuxième message (même juste *« réessaie »*) et Claude les prendra en compte. À partir de là, le reste de votre session fonctionne normalement.
+
+---
+
 ## Dépannage
 
 | Symptôme | Solution |

--- a/product-guides/leadbay-mcp.md
+++ b/product-guides/leadbay-mcp.md
@@ -112,6 +112,16 @@ When a new release ships, repeat **Step 1** (download the new `.mcpb`) and **Ste
 
 ---
 
+## Using Leadbay with Claude Desktop
+
+Claude Desktop is slower than Cowork to load MCP tools, so a couple of extra precautions help.
+
+After installing the Leadbay extension, **fully quit and relaunch Claude Desktop** (Cmd-Q on Mac, then reopen — not just closing the window). Open a new chat and wait about **30 seconds** before sending your first message. This gives Claude time to load the Leadbay tools.
+
+If your first message gets a response like *"I don't see any Leadbay tools"* or *"I can't find Leadbay in your setup"*, don't worry — the tools are still loading. Send any second message (even just *"try again"*) and Claude will pick them up. From that point on, the rest of your session works normally.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Fix |


### PR DESCRIPTION
## Summary
- Add a "Using Leadbay with Claude Desktop" section to the Leadbay MCP guide (EN + FR) covering the full quit/relaunch, ~30s wait, and "send a second message if the first one didn't see the tools" fallback.
- Motivation: Claude Desktop is noticeably slower than Cowork to load MCP tools, so users were hitting confusing "I don't see any Leadbay tools" responses on their first message.

## Test plan
- [ ] Render both guides in GitBook preview and confirm the new section appears between Updating and Troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)