### PR TITLE
Replace bearer token with OAuth sign-in in Leadbay MCP guide

### DIFF
--- a/fr/news/changelog.md
+++ b/fr/news/changelog.md
@@ -14,6 +14,7 @@ Leadbay publie des mises à jour chaque semaine. Voici les étapes majeures.
 - **Intégration Salesforce** : une nouvelle option Salesforce apparaît dans le sélecteur d'intégrations aux côtés de Zapier et SFTP — connectez vos données CRM directement.
 - **Affichage du score final affiné** : la décomposition du score sur les fiches leads a été resserrée — plus facile à lire en un coup d'œil.
 - **Serveur MCP Leadbay** : un tout nouveau serveur **Model Context Protocol** permet à Claude (Desktop, Code, Cowork) de récupérer des leads, les qualifier, enrichir des contacts et journaliser les actions de prospection pour vous — en utilisant votre compte Leadbay. Voir [Leadbay MCP](../product-guides/leadbay-mcp.md) pour le guide d'installation.
+- **Connexion OAuth pour Leadbay MCP** : l'extension MCP s'authentifie désormais via un flux **Se connecter avec Leadbay** en un clic à l'installation — fini le terminal, fini les bearer tokens à générer, copier, coller ou faire tourner. Les installations existantes continuent de fonctionner ; les nouvelles tiennent en une seule approbation. Voir [Leadbay MCP](../product-guides/leadbay-mcp.md) pour les étapes mises à jour.
 
 ## Avril 2026
 

--- a/fr/product-guides/leadbay-mcp.md
+++ b/fr/product-guides/leadbay-mcp.md
@@ -14,7 +14,7 @@ Le serveur MCP est open source et se trouve sur [github.com/leadbay/leadclaw](ht
 
 - Un compte Leadbay ([inscrivez-vous ici](https://leadbay.ai/) si vous n'en avez pas)
 - Claude Cowork (ou tout client Claude qui supporte les extensions MCP)
-- Deux minutes
+- Une minute
 
 ---
 
@@ -26,30 +26,7 @@ Sauvegardez-le dans un endroit facile à retrouver — votre dossier Télécharg
 
 ---
 
-## Étape 2 — Générer un bearer token Leadbay
-
-L'extension a besoin d'un token pour parler à Leadbay en votre nom.
-
-1. Ouvrez un terminal
-2. Lancez :
-
-   ```bash
-   npx -y @leadbay/mcp@latest login --email vous@votreentreprise.com --region fr
-   ```
-
-   - Remplacez `vous@votreentreprise.com` par votre email de connexion Leadbay
-   - Utilisez `--region fr` si vous vous êtes inscrit sur l'instance française, `--region us` pour l'instance US
-
-3. Votre mot de passe vous sera demandé (utilisé une seule fois pour s'authentifier, puis jeté)
-4. La CLI imprime un **bearer token** (commence par `u.`). Copiez-le — vous le collerez à l'étape 4
-
-{% hint style="warning" %}
-Traitez le token comme un mot de passe. Quiconque a ce token peut agir sur votre compte Leadbay.
-{% endhint %}
-
----
-
-## Étape 3 — Installer l'extension dans Cowork
+## Étape 2 — Installer l'extension dans Cowork
 
 Dans Claude Cowork, allez dans :
 
@@ -63,17 +40,24 @@ Une fois installée, basculez l'extension sur **Enabled**.
 
 ---
 
-## Étape 4 — Configurer le token
+## Étape 3 — Se connecter avec Leadbay
 
-Toujours dans **Settings → Extensions**, trouvez Leadbay dans la liste et cliquez sur **Configure**.
+La première fois que Claude appelle un outil Leadbay, il déclenche un flux **Se connecter avec Leadbay** en un clic :
 
-- Collez votre bearer token dans le champ `LEADBAY_TOKEN`
-- Définissez le champ `LEADBAY_REGION` pour correspondre à celui utilisé lors du login (`us` ou `fr`)
-- Sauvegardez
+1. Une page de connexion Leadbay s'ouvre dans votre navigateur
+2. Connectez-vous (ou confirmez votre session existante)
+3. Cliquez sur **Approuver** pour donner à Claude l'accès à votre compte
+4. L'onglet du navigateur se ferme tout seul et Claude poursuit la conversation
+
+Et voilà — aucun token à générer, copier, coller ou faire tourner. La connexion est scopée à votre compte et vous pouvez la révoquer à tout moment depuis **Settings → Connected apps** dans Leadbay.
+
+{% hint style="info" %}
+Si vous avez accès aux deux instances de Leadbay (US et EU), connectez-vous sur celle que vous voulez que Claude utilise. Vous pouvez changer plus tard en vous déconnectant depuis l'extension Leadbay dans Cowork et en vous reconnectant sur l'autre instance.
+{% endhint %}
 
 ---
 
-## Étape 5 — Autoriser les outils
+## Étape 4 — Autoriser les outils
 
 Leadbay livre deux saveurs d'outils :
 
@@ -108,7 +92,7 @@ La liste complète des outils et des workflows recommandés est dans le [README 
 
 ## Mettre à jour
 
-Quand une nouvelle release sort, répétez l'**étape 1** (téléchargez le nouveau `.mcpb`) et l'**étape 3** (Install extension). Cowork remplace l'ancienne version en place ; votre token et vos permissions restent configurés.
+Quand une nouvelle release sort, répétez l'**étape 1** (téléchargez le nouveau `.mcpb`) et l'**étape 2** (Install extension). Cowork remplace l'ancienne version en place ; votre connexion reste valide, donc pas besoin de vous ré-authentifier.
 
 ---
 
@@ -126,8 +110,8 @@ Si votre premier message reçoit une réponse du genre *« Je ne vois pas d'outi
 
 | Symptôme | Solution |
 |----------|----------|
-| Claude dit « non authentifié » ou erreurs 401 | Le token a peut-être expiré. Refaites l'**étape 2** pour en générer un nouveau et collez-le dans **Configure** |
+| Claude dit « non authentifié » ou erreurs 401 | Votre connexion a peut-être expiré ou été révoquée. Déclenchez n'importe quel outil Leadbay et Claude vous reproposera le flux **Se connecter avec Leadbay** |
 | Les outils n'apparaissent pas dans Cowork | Vérifiez que l'extension est bien sur **Enabled** dans Settings → Extensions |
 | Les outils apparaissent mais Claude ne les appelle pas | Ouvrez **Configure** et passez les groupes d'outils en **Always allow** |
-| Mauvaise région (pas de leads / 404s) | Confirmez que `LEADBAY_REGION` correspond à l'endroit où vous vous êtes inscrit (`us` vs `fr`) |
+| Mauvaise instance (pas de leads / 404s) | Déconnectez-vous depuis l'extension Leadbay et reconnectez-vous sur la bonne instance (US ou EU) |
 | Autre problème | Ouvrez un bug sur [github.com/leadbay/leadclaw/issues](https://github.com/leadbay/leadclaw/issues) |

--- a/news/changelog.md
+++ b/news/changelog.md
@@ -14,6 +14,7 @@ Leadbay ships updates every week. Below are the major milestones.
 - **Salesforce integration**: a new Salesforce option appears in the integrations picker alongside Zapier and SFTP — connect your CRM data directly.
 - **Refined final-score display**: the score breakdown on lead profiles has been tightened — easier to read at a glance.
 - **Leadbay MCP server**: a brand-new **Model Context Protocol** server lets Claude (Desktop, Code, Cowork) pull leads, qualify them, enrich contacts, and log outreach on your behalf — using your Leadbay account. See [Leadbay MCP](../product-guides/leadbay-mcp.md) for the install walkthrough.
+- **OAuth sign-in for Leadbay MCP**: the MCP extension now authenticates with a one-tap **Sign in with Leadbay** flow on install — no more terminal, no more bearer tokens to mint, copy, paste, or rotate. Existing installs keep working; new ones are a single approval click. See [Leadbay MCP](../product-guides/leadbay-mcp.md) for the refreshed steps.
 
 ## April 2026
 

--- a/product-guides/leadbay-mcp.md
+++ b/product-guides/leadbay-mcp.md
@@ -14,7 +14,7 @@ The MCP server is open source and lives at [github.com/leadbay/leadclaw](https:/
 
 - A Leadbay account ([sign up here](https://leadbay.ai/) if you don't have one)
 - Claude Cowork (or any Claude client that supports MCP extensions)
-- Two minutes
+- One minute
 
 ---
 
@@ -26,30 +26,7 @@ Save it somewhere easy to find — your Downloads folder works.
 
 ---
 
-## Step 2 — Mint a Leadbay bearer token
-
-The extension needs a token to talk to Leadbay on your behalf.
-
-1. Open a terminal
-2. Run:
-
-   ```bash
-   npx -y @leadbay/mcp@latest login --email you@yourcompany.com --region us
-   ```
-
-   - Replace `you@yourcompany.com` with your Leadbay login email
-   - Use `--region us` if you signed up on the US instance, `--region fr` for the French instance
-
-3. You'll be prompted for your password (it's used once to authenticate, then discarded)
-4. The CLI prints a **bearer token** (starts with `u.`). Copy it — you'll paste it in Step 4
-
-{% hint style="warning" %}
-Treat the token like a password. Anyone with this token can act on your Leadbay account.
-{% endhint %}
-
----
-
-## Step 3 — Install the extension in Cowork
+## Step 2 — Install the extension in Cowork
 
 In Claude Cowork, go to:
 
@@ -63,17 +40,24 @@ Once installed, toggle the extension to **Enabled**.
 
 ---
 
-## Step 4 — Configure the token
+## Step 3 — Sign in with Leadbay
 
-Still in **Settings → Extensions**, find Leadbay in the list and click **Configure**.
+The first time Claude calls a Leadbay tool, it triggers a one-tap **Sign in with Leadbay** flow:
 
-- Paste your bearer token in the `LEADBAY_TOKEN` field
-- Set the `LEADBAY_REGION` field to match the one you used at login (`us` or `fr`)
-- Save
+1. A Leadbay login page opens in your browser
+2. Log in (or confirm your existing session)
+3. Click **Approve** to grant Claude access to your account
+4. The browser tab closes itself and Claude continues the conversation
+
+That's it — no tokens to mint, copy, paste, or rotate. The connection is scoped to your account and you can revoke it anytime from **Settings → Connected apps** in Leadbay.
+
+{% hint style="info" %}
+If you have access to both the US and EU instances of Leadbay, sign in on the instance you want Claude to use. You can switch later by signing out from the Leadbay extension in Cowork and signing back in on the other instance.
+{% endhint %}
 
 ---
 
-## Step 5 — Allow the tools
+## Step 4 — Allow the tools
 
 Leadbay ships two flavors of tools:
 
@@ -108,7 +92,7 @@ The full list of tools and recommended workflows is in the [LeadClaw README](htt
 
 ## Updating
 
-When a new release ships, repeat **Step 1** (download the new `.mcpb`) and **Step 3** (Install extension). Cowork replaces the old version in place; your token and permissions stay configured.
+When a new release ships, repeat **Step 1** (download the new `.mcpb`) and **Step 2** (Install extension). Cowork replaces the old version in place; your sign-in stays valid, so you don't need to re-authenticate.
 
 ---
 
@@ -126,8 +110,8 @@ If your first message gets a response like *"I don't see any Leadbay tools"* or 
 
 | Symptom | Fix |
 |---------|-----|
-| Claude says "not authenticated" or 401 errors | The token may have expired. Repeat **Step 2** to mint a fresh one and paste it in **Configure** |
+| Claude says "not authenticated" or 401 errors | Your sign-in may have expired or been revoked. Trigger any Leadbay tool again and Claude will re-prompt the **Sign in with Leadbay** flow |
 | Tools don't appear in Cowork | Make sure the extension toggle is **Enabled** in Settings → Extensions |
 | Tools appear but Claude won't call them | Open **Configure** and switch the tool groups to **Always allow** |
-| Wrong region (no leads / 404s) | Confirm `LEADBAY_REGION` matches where you signed up (`us` vs `fr`) |
+| Wrong instance (no leads / 404s) | Sign out from the Leadbay extension and sign back in on the right instance (US or EU) |
 | Other issue | File a bug at [github.com/leadbay/leadclaw/issues](https://github.com/leadbay/leadclaw/issues) |


### PR DESCRIPTION
## Summary
- Leadbay MCP authentication switched from CLI-minted bearer tokens to a one-tap **Sign in with Leadbay** OAuth flow that fires on first tool call — no terminal, no token to paste, no `LEADBAY_TOKEN` / `LEADBAY_REGION` env vars.
- Rewrote the install guide (English + French) to drop the token-minting and token-configuration steps, added an OAuth step and refreshed the troubleshooting table (401 → re-trigger sign-in; wrong region → sign out and back in on the right instance).
- Added a May 2026 changelog entry in both locales calling out the simplified sign-in.

## Test plan
- [ ] Render `product-guides/leadbay-mcp.md` and `fr/product-guides/leadbay-mcp.md` in GitBook preview and confirm the four numbered steps flow cleanly.
- [ ] Confirm the new May 2026 OAuth bullet appears below the existing MCP entry in both `news/changelog.md` and `fr/news/changelog.md`.
- [ ] Spot-check intra-doc links to `../product-guides/leadbay-mcp.md` still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)