### PR TITLE
docs(mcp): Milan feedback — simpler intro, direct download, teaser homepage

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -19,6 +19,7 @@
 
 ## Leadbay MCP
 
+* [Leadbay MCP](leadbay-mcp/README.md)
 * [What is Leadbay MCP?](leadbay-mcp/what-is-leadbay-mcp.md)
 * [Quickstart](leadbay-mcp/quickstart.md)
 * [Installation](leadbay-mcp/installation.md)

--- a/leadbay-mcp/README.md
+++ b/leadbay-mcp/README.md
@@ -1,0 +1,43 @@
+---
+description: Your leads, worked by simply asking Claude.
+---
+
+# Leadbay MCP
+
+**Your AI assistant, now plugged into your leads.** Pull prospects, research them, draft outreach, and log activity — in plain language, on your real Leadbay data. No new dashboard to learn.
+
+{% content-ref url="quickstart.md" %}
+[Get started in 2 minutes →](quickstart.md)
+{% endcontent-ref %}
+
+---
+
+## See it in action
+
+<figure><img src=".gitbook/assets/PLACEHOLDER-pull-leads.png" alt="Claude returning today's leads as a ranked shortlist in chat"><figcaption><p><strong>Ask for leads, get a shortlist.</strong> "Show me today's best prospects" → a ranked list with why each fits and the best contact to reach.</figcaption></figure>
+
+<figure><img src=".gitbook/assets/PLACEHOLDER-outreach-draft.png" alt="Claude drafting a personalized outreach email with multiple strategy variants"><figcaption><p><strong>It doesn't just list — it acts.</strong> "Draft me an outreach email for them" → a personalized draft, ready to open in your mail client.</figcaption></figure>
+
+{% hint style="info" %}
+Screenshots above are placeholders — wire in the real hero shots once [PR #11](https://github.com/leadbay/userdoc/pull/11)'s assets land on `main` (`mcp-pull-leads-shortlist.png`, `mcp-outreach-draft-brooklyn.png`).
+{% endhint %}
+
+---
+
+## Keep exploring
+
+{% content-ref url="what-is-leadbay-mcp.md" %}
+[What is Leadbay MCP?](what-is-leadbay-mcp.md)
+{% endcontent-ref %}
+
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="example-prompts.md" %}
+[Example prompts](example-prompts.md)
+{% endcontent-ref %}
+
+{% content-ref url="tools-reference.md" %}
+[Tools reference](tools-reference.md)
+{% endcontent-ref %}

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -25,9 +25,13 @@ The MCP server uses **your** Leadbay account, so any action Claude takes is the 
 
 For **Claude Desktop and Claude Cowork**, the simplest setup is to download a single extension file and double-click it. (Using Claude Code, Cursor, or Codex instead? Skip to the [one-command installer](#one-command-installer-claude-code-cursor-codex) below.)
 
-### Step 1 — Download the latest extension
+### Step 1 — Download the extension
 
-Open the [LeadClaw releases page](https://github.com/leadbay/leadclaw/releases/latest) and download the latest `.dxt` file (look for a name like `leadbay-X.Y.Z.dxt` under the release's **Assets**).
+**[⬇ Download the Leadbay extension (.dxt)](https://get.leadbay.app/leadbay.dxt)** — this downloads the file directly, no page to navigate.
+
+{% hint style="info" %}
+Prefer to grab it manually? Open the [LeadClaw releases page](https://github.com/leadbay/leadclaw/releases/latest) and download the latest `.dxt` (a name like `leadbay-X.Y.Z.dxt`) under the release's **Assets**.
+{% endhint %}
 
 ---
 
@@ -64,8 +68,8 @@ Leadbay ships two flavors of tools:
 
 | Flavor | What's in it | Recommended permission |
 |--------|--------------|------------------------|
-| **Read-only** | Pulls leads, lenses, profiles, contacts, taste profile, enrichment quota — never changes anything | **Always allow** |
-| **Write / delete** | Qualifies leads, enriches contacts, adds notes, imports leads, reports outreach, refines audience | **Always allow** |
+| **Read-only** | Pulls leads, profiles, contacts, and account info — never changes anything | **Always allow** |
+| **Write / delete** | Qualifies leads, enriches contacts, adds notes, imports leads, reports outreach | **Always allow** |
 
 Both flavors are safe to always-allow because the Leadbay MCP is **scoped to your account** — there's nothing destructive at the platform level. Setting both to "always allow" makes Claude flow without interrupting you for permission on every call.
 

--- a/leadbay-mcp/what-is-leadbay-mcp.md
+++ b/leadbay-mcp/what-is-leadbay-mcp.md
@@ -20,7 +20,7 @@ Instead of switching between the Leadbay app and your workflow, you work convers
 
 > *I just emailed Jane at Acme. Log it as outreach.*
 
-Claude reads your leads, lenses, and taste profile, reasons over them, and replies with a short, qualified answer — then takes the follow-up action you ask for.
+Claude reads your real data, reasons over it, and replies with a short, qualified answer — then takes the follow-up action you ask for.
 
 ---
 
@@ -36,19 +36,14 @@ Leadbay MCP works with any AI assistant that supports the Model Context Protocol
 
 ---
 
-## Key concepts
+## What Claude can do
 
-A few Leadbay terms show up in prompts and responses. You don't need to manage any of them to get started — Claude handles the details — but knowing what they mean helps:
-
-| Term | What it means |
+| | |
 |------|---------------|
-| **Lens** | Your saved audience — the sector, company size, and criteria that define which leads Leadbay surfaces. You can have several and switch between them ("switch to my Joinery lens"). |
-| **Score** | A 0–100 firmographic fit score on every lead — how well it matches your audience. Shown as a bar in lead tables. |
-| **AI score** | A deeper qualification score on the top leads in each batch, from targeted web research against your qualification questions. Most leads ship with the basic score; the best get AI-qualified. |
-| **Taste profile** | What Leadbay learns from your likes, dislikes, and outreach — it tunes future scoring to your judgement. Liking a lead in chat teaches it. |
-| **Read vs write** | **Read** tools only pull data (leads, profiles, contacts) and never change anything. **Write** tools take action (qualify, enrich, log outreach, edit lenses). Both are scoped to your account — every write is something you could do yourself in the app, with nothing destructive at the platform level. You control how much your client asks before each action through its tool-permission settings. |
+| **Read** | Pulls leads, profiles, and contacts — never changes anything. |
+| **Act** | Qualifies, enriches, drafts and logs outreach, imports lists — every action is something you could do yourself in the app. |
 
-These are covered in depth in the [Lenses](../product-guides/lenses.md) and [AI Assistant](../product-guides/ai-assistant.md) product guides.
+Everything is scoped to your account, with nothing destructive at the platform level. You control how much Claude asks before each action through your client's tool-permission settings.
 
 ---
 


### PR DESCRIPTION
Applies Milan's review of the Leadbay MCP docs section. **EN only** this pass — FR mirrors once the preview is approved.

**Changes**
- **What is Leadbay MCP** — removed the *Key concepts* table (Lens / Score / AI score / Taste profile) and the "lenses, taste profile" mentions. A first-touch page shouldn't lead with internal vocabulary; replaced with a short read-vs-act note.
- **Installation** — Step 1 now leads with a **direct `.dxt` download link** (one click, no releases page to navigate); the releases page is kept only as a manual fallback.
- **Homepage** — the `## Leadbay MCP` section was a bare clickless menu. Added `leadbay-mcp/README.md` as a teaser landing (value prop + prominent Quickstart CTA + figure slots) and wired it into `SUMMARY.md`.

**⚠ One prerequisite — the direct download link.** The install copy points at `https://get.leadbay.app/leadbay.dxt`, a short stable redirect to the newest `.dxt`. **That redirect does not exist yet** — it needs setting up (GitHub's asset URL is versioned per release, so it can't be hardcoded). Until it's live the link 404s. Owner: whoever controls Leadbay DNS.

**Note on images** — the teaser homepage uses placeholder figures. The real hero screenshots (`mcp-pull-leads-shortlist.png`, `mcp-outreach-draft-brooklyn.png`) live on #11 and aren't on `main` yet; swap them in once #11 lands.