### PR TITLE
docs(mcp): add admin setup page for org installation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -22,6 +22,7 @@
 * [What is Leadbay MCP?](leadbay-mcp/what-is-leadbay-mcp.md)
 * [Quickstart](leadbay-mcp/quickstart.md)
 * [Installation](leadbay-mcp/installation.md)
+* [Admin setup](leadbay-mcp/admin-setup.md)
 * [Tools reference](leadbay-mcp/tools-reference.md)
 * [Example prompts](leadbay-mcp/example-prompts.md)
 

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -57,13 +57,30 @@ members' connector directory.
 {% hint style="info" %}
 **Members can't add it themselves.** In a Team or Enterprise workspace, members
 don't have the **Add custom connector** option — that's exactly why this admin
-step exists. Once you've added it, they just search "Leadbay", open it, click
-**Connect**, and sign in.
+step exists.
 {% endhint %}
 
-**What your members do next:** point them at the [Quickstart](quickstart.md). They
-open the **Leadbay** connector, click **Connect**, and sign in with their own
-Leadbay account — no further admin involvement needed.
+### What your members do next
+
+Once you've added the connector, send your team these three steps (no admin
+rights needed — each person signs in with their own Leadbay account):
+
+**1. Find the Leadbay connector.** In Claude, open **Settings → Connectors** and
+search "Leadbay" — it appears under **Custom connectors**. Open it.
+
+<figure><img src="../.gitbook/assets/claude-03-directory-search.png" alt="Directory search showing the Leadbay custom connector"><figcaption><p>Search "Leadbay" and open the connector the admin added</p></figcaption></figure>
+
+**2. Click Connect and sign in.** A **Sign in with Leadbay** page opens in the
+browser — log in and click **Approve**. The tab closes and the connector shows as
+connected.
+
+<figure><img src="../.gitbook/assets/claude-04-connect.png" alt="Leadbay connector with the Connect button"><figcaption><p>Click Connect, then sign in with Leadbay</p></figcaption></figure>
+
+**3. Ask for leads.** Open a new chat and try _"Show me today's leads."_ Claude
+replies with a ranked shortlist — that means it's fully connected. 🎉
+
+The full member walkthrough (with the first-message tips) lives in the
+[Quickstart](quickstart.md).
 
 ---
 
@@ -79,10 +96,18 @@ On Business and Enterprise workspaces, custom MCP connectors are off until a
    apps for members).
 3. Let your members know they can now add Leadbay.
 
-**What your members do next:** each member follows the **ChatGPT** section of the
-[Installation](installation.md) guide — turn on Developer mode, **Create app**
-with **Name** `Leadbay MCP`, **Server URL** `https://mcp.leadbay.app/mcp`, and
-**OAuth**, then sign in with their own Leadbay account.
+### What your members do next
+
+Unlike Claude, ChatGPT members add the app themselves once you've allowed custom
+connectors. Send them the **ChatGPT** section of the
+[Installation](installation.md) guide — each member:
+
+1. Turns on **Developer mode** (Settings → Apps → Advanced settings).
+2. Clicks **Create app** and fills in **Name** `Leadbay MCP`, **Server URL**
+   `https://mcp.leadbay.app/mcp`, and **Authentication: OAuth**.
+3. Clicks **Sign in with Leadbay MCP** and logs in with their own Leadbay account.
+4. Enables the **Leadbay MCP** app from the composer **+** / tools menu, then asks
+   for leads.
 
 {% hint style="info" %}
 The exact wording and location of the "allow custom connectors" control changes

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -91,55 +91,11 @@ settings for **connectors** or **apps**, or check OpenAI's current admin
 documentation.
 {% endhint %}
 
----
-
-## Claude Code & Codex — no admin step
-
-The command-line clients (**Claude Code**, **Codex**) connect per user — there's
-no organization gate to open. Each member just runs the one-line add command from
-the [Installation](installation.md) guide on their own machine:
-
-```bash
-# Claude Code
-claude mcp add --scope user --transport http leadbay https://mcp.leadbay.app/mcp
-
-# Codex
-codex mcp add leadbay --url https://mcp.leadbay.app/mcp
-```
-
-Nothing for you to do as an admin — you can simply forward them the Installation
-guide.
-
----
-
-## Fallback: install the `.dxt` extension (no admin needed)
-
-Can't get the connector URL to work — the **Add custom connector** option is
-missing, your admin can't add it, or the URL route just won't cooperate? On
-**Claude Desktop** there's a second path that doesn't touch the organization
-connector at all: install Leadbay as a **`.dxt` extension**. It's a per-user
-double-click install, so any member can do it themselves.
-
-1. **[⬇ Download the Leadbay extension (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)** — this pulls the latest version directly.
-2. **Double-click the downloaded `.dxt`.** Claude opens with the extension
-   details — click **Install**, then toggle the extension to **Enabled**.
-3. Open a new chat, click **Connect** on the extension, and sign in with your
-   Leadbay account (same one-tap **Sign in with Leadbay** flow — no tokens).
-
 {% hint style="info" %}
-Claude didn't open on double-click? Install it from inside the app:
-**Settings → Extensions → Advanced → Install extension**, then pick the `.dxt`
-file you downloaded.
+**Claude Code and Codex need no admin step** — they're per-user CLI clients with
+no organization gate. Each member just runs the one-line add command from the
+[Installation](installation.md) guide on their own machine.
 {% endhint %}
-
-{% hint style="info" %}
-The `.dxt` route is **Claude Desktop only**. For Claude.ai (web) and ChatGPT,
-the custom connector is the only path — if it's missing, that's an admin gate,
-so use the sections above. Claude Code and Codex use their one-line commands.
-{% endhint %}
-
-When a new release ships, repeat step 1 (download the new `.dxt`, double-click,
-Install). Claude replaces the old version in place and your sign-in carries over.
 
 ---
 

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -1,0 +1,131 @@
+# Admin setup
+
+**For workspace and organization admins.** This page walks you through adding the
+Leadbay connector once, for your whole organization, so every member can connect
+without needing admin rights themselves.
+
+If you landed here because a teammate asked you to "add the Leadbay connector" —
+you're in the right place. It takes a couple of minutes, there are no API tokens
+to hand out, and each member still signs in with **their own** Leadbay account.
+
+{% hint style="info" %}
+**Are you sure you need this?** Only **organization** plans gate custom connectors
+behind an admin:
+
+- **Claude** — Team and Enterprise workspaces.
+- **ChatGPT** — Business and Enterprise workspaces.
+
+On an individual paid plan (Claude Pro/Max, ChatGPT Plus/Pro), there's no admin
+step — you can add the connector yourself. Just follow the
+[Quickstart](quickstart.md) or [Installation](installation.md) guide.
+{% endhint %}
+
+{% hint style="warning" %}
+**US vs EU accounts.** Everywhere the server URL is asked for, it's
+`https://mcp.leadbay.app/mcp`. If your organization's Leadbay account is on the
+**EU** instance, use `https://mcp.leadbay.app/fr/mcp` instead. When in doubt, the
+US URL works for most accounts — a valid login is routed to whichever backend owns
+it.
+{% endhint %}
+
+---
+
+## Claude (Team & Enterprise)
+
+As a **primary owner or admin**, you add Leadbay as an **organization** custom
+connector. Once it's added, it appears in every member's connector directory and
+they connect to it individually.
+
+**1. Open the Add custom connector form.** Use this link (or in Claude, go to
+**Settings → Connectors**, then the **+** next to the search bar → **Add custom
+connector**):
+
+{% hint style="info" %}
+[https://claude.ai/customize/connectors?modal=add-custom-connector](https://claude.ai/customize/connectors?modal=add-custom-connector)
+{% endhint %}
+
+<figure><img src="../.gitbook/assets/claude-02-connectors-plus-menu.png" alt="Connectors + menu with Add custom connector"><figcaption><p>The + menu → Add custom connector</p></figcaption></figure>
+
+**2. Add it for the organization.** Fill in the fields, and if Claude offers a
+choice of scope (organization vs. just you), choose the **organization** scope so
+every member gets it:
+
+- **Name:** `Leadbay`
+- **URL:** `https://mcp.leadbay.app/mcp`
+
+Leave the Advanced settings as they are — **Individual sign-in** is what you want.
+Each member authenticates with their own Leadbay login; you are **not** sharing
+one account across the team.
+
+<figure><img src="../.gitbook/assets/claude-01-add-custom-connector-form.png" alt="Add custom connector form with Leadbay name and URL"><figcaption><p>Name it Leadbay, paste the URL, click Add</p></figcaption></figure>
+
+**3. Click Add.** That's the admin part done — Leadbay now shows up in your
+members' connector directory.
+
+{% hint style="info" %}
+**Members can't add it themselves.** In a Team or Enterprise workspace, members
+don't have the **Add custom connector** option — that's exactly why this admin
+step exists. Once you've added it, they just search "Leadbay", open it, click
+**Connect**, and sign in.
+{% endhint %}
+
+**What your members do next:** point them at the [Quickstart](quickstart.md). They
+open the **Leadbay** connector, click **Connect**, and sign in with their own
+Leadbay account — no further admin involvement needed.
+
+---
+
+## ChatGPT (Business & Enterprise)
+
+On Business and Enterprise workspaces, custom MCP connectors are off until a
+**workspace owner or admin** allows them. You don't add Leadbay for everyone here
+— you unlock the ability, and each member then adds it themselves.
+
+1. Open your **workspace settings** (workspace menu, bottom-left → **Settings**).
+2. Under the connector / apps controls, **allow custom connectors** for the
+   workspace (this is the workspace-level switch that gates Developer-mode custom
+   apps for members).
+3. Let your members know they can now add Leadbay.
+
+**What your members do next:** each member follows the **ChatGPT** section of the
+[Installation](installation.md) guide — turn on Developer mode, **Create app**
+with **Name** `Leadbay MCP`, **Server URL** `https://mcp.leadbay.app/mcp`, and
+**OAuth**, then sign in with their own Leadbay account.
+
+{% hint style="info" %}
+The exact wording and location of the "allow custom connectors" control changes
+as ChatGPT's admin console evolves. If you can't find it, search the workspace
+settings for **connectors** or **apps**, or check OpenAI's current admin
+documentation.
+{% endhint %}
+
+---
+
+## Claude Code & Codex — no admin step
+
+The command-line clients (**Claude Code**, **Codex**) connect per user — there's
+no organization gate to open. Each member just runs the one-line add command from
+the [Installation](installation.md) guide on their own machine:
+
+```bash
+# Claude Code
+claude mcp add --scope user --transport http leadbay https://mcp.leadbay.app/mcp
+
+# Codex
+codex mcp add leadbay --url https://mcp.leadbay.app/mcp
+```
+
+Nothing for you to do as an admin — you can simply forward them the Installation
+guide.
+
+---
+
+## Where to next
+
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="quickstart.md" %}
+[Quickstart](quickstart.md)
+{% endcontent-ref %}

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -120,6 +120,37 @@ guide.
 
 ---
 
+## Fallback: install the `.dxt` extension (no admin needed)
+
+Can't get the connector URL to work — the **Add custom connector** option is
+missing, your admin can't add it, or the URL route just won't cooperate? On
+**Claude Desktop** there's a second path that doesn't touch the organization
+connector at all: install Leadbay as a **`.dxt` extension**. It's a per-user
+double-click install, so any member can do it themselves.
+
+1. **[⬇ Download the Leadbay extension (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)** — this pulls the latest version directly.
+2. **Double-click the downloaded `.dxt`.** Claude opens with the extension
+   details — click **Install**, then toggle the extension to **Enabled**.
+3. Open a new chat, click **Connect** on the extension, and sign in with your
+   Leadbay account (same one-tap **Sign in with Leadbay** flow — no tokens).
+
+{% hint style="info" %}
+Claude didn't open on double-click? Install it from inside the app:
+**Settings → Extensions → Advanced → Install extension**, then pick the `.dxt`
+file you downloaded.
+{% endhint %}
+
+{% hint style="info" %}
+The `.dxt` route is **Claude Desktop only**. For Claude.ai (web) and ChatGPT,
+the custom connector is the only path — if it's missing, that's an admin gate,
+so use the sections above. Claude Code and Codex use their one-line commands.
+{% endhint %}
+
+When a new release ships, repeat step 1 (download the new `.dxt`, double-click,
+Install). Claude replaces the old version in place and your sign-in carries over.
+
+---
+
 ## Where to next
 
 {% content-ref url="installation.md" %}

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -20,14 +20,6 @@ step — you can add the connector yourself. Just follow the
 [Quickstart](quickstart.md) or [Installation](installation.md) guide.
 {% endhint %}
 
-{% hint style="warning" %}
-**US vs EU accounts.** Everywhere the server URL is asked for, it's
-`https://mcp.leadbay.app/mcp`. If your organization's Leadbay account is on the
-**EU** instance, use `https://mcp.leadbay.app/fr/mcp` instead. When in doubt, the
-US URL works for most accounts — a valid login is routed to whichever backend owns
-it.
-{% endhint %}
-
 ---
 
 ## Claude (Team & Enterprise)

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -17,10 +17,6 @@ https://mcp.leadbay.app/mcp
 Sign-in is handled by your browser (OAuth) — there are no tokens to copy or paste.
 {% endhint %}
 
-{% hint style="warning" %}
-**US vs EU accounts.** If your Leadbay account is on the **EU** instance, use `https://mcp.leadbay.app/fr/mcp` instead of `https://mcp.leadbay.app/mcp`. When in doubt, the US URL works for most accounts — a valid login is routed to whichever backend owns it.
-{% endhint %}
-
 ---
 
 ## Claude.ai (web)
@@ -197,8 +193,7 @@ A successful reply is a **ranked shortlist** — each lead with a fit score, a o
 | Symptom | Fix |
 |---------|-----|
 | "Not authenticated" / 401 errors | Your sign-in expired or was revoked. Trigger any Leadbay tool again and approve the **Sign in with Leadbay** prompt. |
-| Connected, but "show me leads" returns an empty list | You're signed in fine — there's just nothing to show right now. Ask _"show me my lenses"_ to check which audience is active, or confirm you're on the right instance (US vs EU). |
-| Wrong instance (no leads / 404s) | Sign out and sign back in on the correct instance, or use the `/fr/mcp` URL for EU accounts. |
+| Connected, but "show me leads" returns an empty list | You're signed in fine — there's just nothing to show right now. Ask _"show me my lenses"_ to check which audience is active. |
 | Tools don't appear after connecting | Open a new chat and wait a few seconds; send a second message and the tools finish loading. |
 | Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the connector in the composer (ChatGPT). |
 | Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](admin-setup.md). |

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -201,7 +201,7 @@ A successful reply is a **ranked shortlist** — each lead with a fit score, a o
 | Wrong instance (no leads / 404s) | Sign out and sign back in on the correct instance, or use the `/fr/mcp` URL for EU accounts. |
 | Tools don't appear after connecting | Open a new chat and wait a few seconds; send a second message and the tools finish loading. |
 | Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the connector in the composer (ChatGPT). |
-| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). |
+| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](admin-setup.md). |
 | Other issue | File a bug at [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
 
 ---

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -71,7 +71,7 @@ Claude Desktop connects to Leadbay exactly like Claude.ai — same **custom conn
 If your first message gets _"I don't see any Leadbay tools"_, the tools are still loading. Send any second message (even just _"try again"_) and Claude will pick them up. As with Claude.ai, if you're not an org admin, the admin must add the connector first — see [Admin setup](admin-setup.md).
 {% endhint %}
 
-### Fallback: install the `.dxt` extension
+### Fallback: install the extension
 
 Can't get the custom connector to work — the **Add custom connector** option is missing, or you're not an org admin? On Claude Desktop you can skip the connector entirely and install Leadbay as a **`.dxt` extension**. It's a per-user double-click install with no admin gate.
 
@@ -208,7 +208,7 @@ A successful reply is a **ranked shortlist** — each lead with a fit score, a o
 | Connected, but "show me leads" returns an empty list | You're signed in fine — there's just nothing to show right now. Ask _"show me my lenses"_ to check which audience is active. |
 | Tools don't appear after connecting | Open a new chat and wait a few seconds; send a second message and the tools finish loading. |
 | Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the connector in the composer (ChatGPT). |
-| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](#fallback-install-the-.dxt-extension). |
+| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](#fallback-install-the-extension). |
 | Other issue | File a bug at [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
 
 ---

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -208,7 +208,7 @@ A successful reply is a **ranked shortlist** — each lead with a fit score, a o
 | Connected, but "show me leads" returns an empty list | You're signed in fine — there's just nothing to show right now. Ask _"show me my lenses"_ to check which audience is active. |
 | Tools don't appear after connecting | Open a new chat and wait a few seconds; send a second message and the tools finish loading. |
 | Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the connector in the composer (ChatGPT). |
-| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](#claude-desktop). |
+| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](#fallback-install-the-.dxt-extension). |
 | Other issue | File a bug at [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
 
 ---

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -71,6 +71,18 @@ Claude Desktop connects to Leadbay exactly like Claude.ai — same **custom conn
 If your first message gets _"I don't see any Leadbay tools"_, the tools are still loading. Send any second message (even just _"try again"_) and Claude will pick them up. As with Claude.ai, if you're not an org admin, the admin must add the connector first — see [Admin setup](admin-setup.md).
 {% endhint %}
 
+### Fallback: install the `.dxt` extension
+
+Can't get the custom connector to work — the **Add custom connector** option is missing, or you're not an org admin? On Claude Desktop you can skip the connector entirely and install Leadbay as a **`.dxt` extension**. It's a per-user double-click install with no admin gate.
+
+1. **[⬇ Download the Leadbay extension (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)** — this pulls the latest version directly.
+2. **Double-click the downloaded `.dxt`.** Claude opens with the extension details — click **Install**, then toggle the extension to **Enabled**.
+3. Open a new chat, click **Connect** on the extension, and sign in with Leadbay in your browser.
+
+{% hint style="info" %}
+Claude didn't open on double-click? Install it from inside the app: **Settings → Extensions → Advanced → Install extension**, then pick the `.dxt` file you downloaded. When a new release ships, download the new `.dxt` and install it again — Claude replaces the old version in place and your sign-in carries over.
+{% endhint %}
+
 ---
 
 ## Claude Code
@@ -196,7 +208,7 @@ A successful reply is a **ranked shortlist** — each lead with a fit score, a o
 | Connected, but "show me leads" returns an empty list | You're signed in fine — there's just nothing to show right now. Ask _"show me my lenses"_ to check which audience is active. |
 | Tools don't appear after connecting | Open a new chat and wait a few seconds; send a second message and the tools finish loading. |
 | Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the connector in the composer (ChatGPT). |
-| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](admin-setup.md). |
+| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](#claude-desktop). |
 | Other issue | File a bug at [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
 
 ---

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -53,7 +53,7 @@ Leave the Advanced settings as they are (Individual sign-in is fine).
 <figure><img src="../.gitbook/assets/claude-04-connect.png" alt="Leadbay connector with the Connect button"><figcaption><p>Click Connect, then sign in with Leadbay</p></figcaption></figure>
 
 {% hint style="warning" %}
-**Not an admin of your organization?** Members can't add a custom connector themselves — your **workspace admin** needs to add the Leadbay connector first (steps 1–2 above). Once the admin has added it, you'll find it in the directory and can **Connect** (steps 3–4).
+**Not an admin of your organization?** Members can't add a custom connector themselves — your **workspace admin** needs to add the Leadbay connector first (steps 1–2 above). Send them the [Admin setup](admin-setup.md) guide. Once the admin has added it, you'll find it in the directory and can **Connect** (steps 3–4).
 {% endhint %}
 
 {% hint style="info" %}
@@ -72,7 +72,7 @@ Claude Desktop connects to Leadbay exactly like Claude.ai — same **custom conn
 4. Open a new chat and wait a few seconds for the Leadbay tools to load before your first message.
 
 {% hint style="info" %}
-If your first message gets _"I don't see any Leadbay tools"_, the tools are still loading. Send any second message (even just _"try again"_) and Claude will pick them up. As with Claude.ai, if you're not an org admin, the admin must add the connector first.
+If your first message gets _"I don't see any Leadbay tools"_, the tools are still loading. Send any second message (even just _"try again"_) and Claude will pick them up. As with Claude.ai, if you're not an org admin, the admin must add the connector first — see [Admin setup](admin-setup.md).
 {% endhint %}
 
 ---
@@ -201,7 +201,7 @@ A successful reply is a **ranked shortlist** — each lead with a fit score, a o
 | Wrong instance (no leads / 404s) | Sign out and sign back in on the correct instance, or use the `/fr/mcp` URL for EU accounts. |
 | Tools don't appear after connecting | Open a new chat and wait a few seconds; send a second message and the tools finish loading. |
 | Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the connector in the composer (ChatGPT). |
-| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them. |
+| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). |
 | Other issue | File a bug at [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
 
 ---

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -18,7 +18,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 3. Click **Add**.
 
 {% hint style="info" %}
-Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#claude-desktop) yourself (a per-user, no-admin install). See [Installation](installation.md) for the full walkthrough with screenshots.
+Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-.dxt-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for the full walkthrough with screenshots.
 {% endhint %}
 
 ---

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -18,7 +18,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 3. Click **Add**.
 
 {% hint style="info" %}
-On the **EU** instance, use `https://mcp.leadbay.app/fr/mcp` instead. Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, your workspace admin needs to add the connector first — then you can connect to it. See [Installation](installation.md) for the full walkthrough with screenshots.
+On the **EU** instance, use `https://mcp.leadbay.app/fr/mcp` instead. Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, your workspace admin needs to add the connector first — send them the [Admin setup](admin-setup.md) guide, then you can connect to it. See [Installation](installation.md) for the full walkthrough with screenshots.
 {% endhint %}
 
 ---

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -18,7 +18,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 3. Click **Add**.
 
 {% hint style="info" %}
-Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-.dxt-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for the full walkthrough with screenshots.
+Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for the full walkthrough with screenshots.
 {% endhint %}
 
 ---

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -18,7 +18,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 3. Click **Add**.
 
 {% hint style="info" %}
-Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, your workspace admin needs to add the connector first — send them the [Admin setup](admin-setup.md) guide, then you can connect to it. See [Installation](installation.md) for the full walkthrough with screenshots.
+Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#claude-desktop) yourself (a per-user, no-admin install). See [Installation](installation.md) for the full walkthrough with screenshots.
 {% endhint %}
 
 ---

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -18,7 +18,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 3. Click **Add**.
 
 {% hint style="info" %}
-On the **EU** instance, use `https://mcp.leadbay.app/fr/mcp` instead. Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, your workspace admin needs to add the connector first — send them the [Admin setup](admin-setup.md) guide, then you can connect to it. See [Installation](installation.md) for the full walkthrough with screenshots.
+Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, your workspace admin needs to add the connector first — send them the [Admin setup](admin-setup.md) guide, then you can connect to it. See [Installation](installation.md) for the full walkthrough with screenshots.
 {% endhint %}
 
 ---


### PR DESCRIPTION
## What

Adds a dedicated **Admin setup** page to the Leadbay MCP docs and points the existing "not an admin?" install hints at it.

## Why

Org members (Claude Team/Enterprise, ChatGPT Business/Enterprise) can't add the Leadbay custom connector themselves — a workspace admin must add or allow it first. The install docs only carried a one-line inline hint and linked back to the end-user Installation page; there was no page walking an admin through the org-wide setup, and no documented fallback when the connector route is blocked.

## Changes

- **New** `leadbay-mcp/admin-setup.md`:
  - Admin walkthrough for **Claude** (Team & Enterprise) and **ChatGPT** (Business & Enterprise), plus a "no admin step needed" note for the Claude Code / Codex CLI clients. US/EU-aware, stresses individual sign-in (no shared account, no tokens).
  - **`.dxt` extension fallback** — for anyone who can't get the connector/MCP-URL route to work, the Claude Desktop `.dxt` extension is a per-user double-click install with no org connector gate. Uses the canonical `leadbay/mcp` release download URL.
- Repointed the "not an admin?" hints in `quickstart.md` and `installation.md` (and the "custom connector option missing" troubleshooting row, which also links the `.dxt` fallback) at the new page.
- Wired the page into `SUMMARY.md` after Installation.

English only for now — `fr/leadbay-mcp/` has no `installation.md` and a reduced page set, so EN is the complete MCP-install surface. FR can follow if wanted.

Docs-only change; no eval coverage applies.

Closes https://github.com/leadbay/product/issues/3837