### PR TITLE
docs(mcp): lead the Quickstart with a 'which one are you?' router

### DIFF
--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -8,6 +8,19 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 
 ---
 
+## First — which one are you?
+
+Adding a custom connector needs a **paid Claude plan**, and in a **company workspace only an admin can add it**. Find your situation, then follow the steps below:
+
+| Your situation | What to do |
+|---|---|
+| **Solo / personal paid plan** (not in a company workspace) | Add it yourself — follow Step 1 below. |
+| **In a company workspace, and you're the admin** | Add it yourself (Step 1) — your teammates then just **Connect**. |
+| **In a company workspace, not the admin** | You can't add it yourself. Send your admin the [Admin setup](admin-setup.md) guide; once they've added it, skip to **Step 2 — Sign in**. |
+| **Can't add connectors / no admin to ask** | On **Claude Desktop**, install the [`.dxt` extension](installation.md#fallback-install-the-extension) instead — a per-user install with no admin gate. |
+
+---
+
 ## Step 1 — Add the Leadbay connector
 
 1. Open the **Add custom connector** form — use this link, or in Claude go to **Settings → Connectors** → the **+** → **Add custom connector**:
@@ -18,7 +31,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 3. Click **Add**.
 
 {% hint style="info" %}
-Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for the full walkthrough with screenshots.
+Prefer step-by-step screenshots, or on a different assistant (Claude Desktop, Claude Code, ChatGPT, Codex)? See the full [Installation](installation.md) walkthrough.
 {% endhint %}
 
 ---


### PR DESCRIPTION
## Problem
The MCP Quickstart is well-written per step, but a new (non-technical) user finds it **messy** because the one fact that gates everything — *"can I even add this connector?"* — is scattered across mid-page hints:
- paid-plan requirement + admin-only-in-a-workspace appear as afterthought hints *after* Step 1, again in Installation, and again in Troubleshooting.

So the reader only discovers whether they can proceed *after* trying (and possibly failing). The info exists 4× but is never the first thing they see.

## Fix (surgical — EN Quickstart only)
Add a **"First — which one are you?"** decision table at the very top, before Step 1, so users self-route in one glance:

| Situation | Action |
|---|---|
| Solo / personal paid plan | Add it yourself |
| Company workspace, you're the admin | Add it yourself; teammates Connect |
| Company workspace, not admin | Send admin the Admin setup guide → then Connect |
| Can't add / no admin | Claude Desktop `.dxt` (no-admin install) |

Then trim the now-redundant mid-step hint to a pointer to the full Installation walkthrough. No step-by-step content changed; +14/−1 lines.

## Not in this PR (flagged separately)
- **`fr/leadbay-mcp/quickstart.md` is stale** — it leads with `.dxt` as "recommended", uses the **old `leadbay/leadclaw` GitHub URL** (repo renamed to `leadbay/mcp`), and says *"ChatGPT support coming soon"* (it's shipped). The FR MCP docs need a broader refresh to match EN — larger scope, worth its own PR.

Draft — for review by whoever owns the docs voice.