### PR TITLE
docs(mcp): terse install docs, one-click connector, region endpoints, FR parity

### DIFF
--- a/fr/SUMMARY.md
+++ b/fr/SUMMARY.md
@@ -21,6 +21,8 @@
 
 * [Qu'est-ce que Leadbay MCP ?](leadbay-mcp/what-is-leadbay-mcp.md)
 * [Démarrage rapide](leadbay-mcp/quickstart.md)
+* [Installation](leadbay-mcp/installation.md)
+* [Configuration admin](leadbay-mcp/admin-setup.md)
 * [Référence des outils](leadbay-mcp/tools-reference.md)
 * [Exemples de prompts](leadbay-mcp/example-prompts.md)
 

--- a/fr/leadbay-mcp/admin-setup.md
+++ b/fr/leadbay-mcp/admin-setup.md
@@ -1,0 +1,59 @@
+# Configuration admin
+
+**Pour les admins d'espace de travail et d'organisation.** Cette page vous guide pour ajouter le connecteur Leadbay une seule fois, pour toute votre organisation, afin que chaque membre puisse se connecter sans avoir besoin de droits admin lui-même.
+
+Si vous êtes arrivé ici parce qu'un collègue vous a demandé d'« ajouter le connecteur Leadbay » — vous êtes au bon endroit. Ça prend deux minutes, il n'y a aucun jeton d'API à distribuer, et chaque membre se connecte toujours avec **son propre** compte Leadbay.
+
+> **Êtes-vous sûr d'en avoir besoin ?** Seuls les plans **organisation** verrouillent les connecteurs personnalisés derrière un admin — **Claude** Team/Enterprise et **ChatGPT** Business/Enterprise. Sur un plan payant individuel (Claude Pro/Max, ChatGPT Plus/Pro), il n'y a pas d'étape admin ; ajoutez le connecteur vous-même via le guide [Démarrage rapide](quickstart.md) ou [Installation](installation.md).
+
+---
+
+## Claude (Team & Enterprise)
+
+En tant que **propriétaire principal ou admin**, ajoutez Leadbay comme connecteur personnalisé d'**organisation**. Une fois ajouté, il apparaît dans le répertoire de chaque membre et ils se connectent individuellement.
+
+1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)** — le formulaire s'ouvre avec le nom et l'URL pré-remplis. (URL France : `https://mcp.leadbay.app/fr/mcp` ; sur l'instance US, utilisez `https://mcp.leadbay.app/mcp`.)
+2. Si Claude propose un choix de portée, choisissez **organisation** pour que chaque membre en bénéficie. Laissez les paramètres avancés tels quels (**Individual sign-in** — chaque membre utilise son propre identifiant Leadbay ; vous ne partagez pas un seul compte), puis cliquez sur **Add**.
+
+C'est fait côté admin — Leadbay apparaît maintenant dans le répertoire de connecteurs de vos membres. (Dans un espace Team/Enterprise, les membres n'ont pas l'option **Add custom connector** eux-mêmes, c'est pourquoi cette étape existe.)
+
+**Ce que font vos membres ensuite :** dans Claude, **Settings → Connectors → cherchez « Leadbay » → Connect**, puis connexion avec leur propre compte Leadbay. Guide complet dans le [Démarrage rapide](quickstart.md).
+
+---
+
+## ChatGPT (Business & Enterprise)
+
+Sur les espaces Business et Enterprise, les connecteurs MCP personnalisés sont désactivés jusqu'à ce qu'un **propriétaire ou admin d'espace de travail** les autorise. Vous n'ajoutez pas Leadbay pour tout le monde ici — vous débloquez la possibilité, et chaque membre l'ajoute ensuite lui-même.
+
+1. Ouvrez les **paramètres de votre espace de travail** (menu d'espace, en bas à gauche → **Settings**).
+2. Sous les contrôles de connecteurs / apps, **autorisez les connecteurs personnalisés** pour l'espace de travail (c'est l'interrupteur au niveau de l'espace qui débloque les apps personnalisées en Developer mode pour les membres).
+3. Prévenez vos membres qu'ils peuvent désormais ajouter Leadbay.
+
+### Ce que font vos membres ensuite
+
+Contrairement à Claude, les membres ChatGPT ajoutent l'application eux-mêmes une fois que vous avez autorisé les connecteurs personnalisés. Envoyez-leur la section **ChatGPT** du guide [Installation](installation.md) — chaque membre :
+
+1. Active le **Developer mode** (Settings → Apps → Advanced settings).
+2. Clique sur **Create app** et remplit **Name** `Leadbay MCP`, **Server URL** `https://mcp.leadbay.app/fr/mcp`, et **Authentication : OAuth**.
+3. Clique sur **Sign in with Leadbay MCP** et se connecte avec son propre compte Leadbay.
+4. Active l'application **Leadbay MCP** depuis le menu **+** / outils du composeur, puis demande des leads.
+
+{% hint style="info" %}
+La formulation et l'emplacement exacts du contrôle « autoriser les connecteurs personnalisés » évoluent avec la console admin de ChatGPT. Si vous ne le trouvez pas, cherchez **connectors** ou **apps** dans les paramètres de l'espace, ou consultez la documentation admin actuelle d'OpenAI.
+{% endhint %}
+
+{% hint style="info" %}
+**Claude Code et Codex ne nécessitent aucune étape admin** — ce sont des clients CLI par utilisateur, sans verrou d'organisation. Chaque membre lance simplement la commande d'ajout en une ligne du guide [Installation](installation.md) sur sa propre machine.
+{% endhint %}
+
+---
+
+## Et ensuite
+
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
+
+{% content-ref url="quickstart.md" %}
+[Démarrage rapide](quickstart.md)
+{% endcontent-ref %}

--- a/fr/leadbay-mcp/installation.md
+++ b/fr/leadbay-mcp/installation.md
@@ -1,0 +1,131 @@
+# Installation
+
+Choisissez votre client ci-dessous. Chacun prend deux minutes et **aucun ne nécessite de jeton d'API** — vous ajoutez une URL de serveur, vous vous connectez une fois avec votre compte Leadbay dans le navigateur, et c'est relié.
+
+Partout où une URL de serveur est demandée, utilisez celle de votre région :
+
+| Région | URL du serveur |
+|---|---|
+| 🇫🇷 France / UE | `https://mcp.leadbay.app/fr/mcp` |
+| 🇺🇸 US | `https://mcp.leadbay.app/mcp` |
+
+Utilisez l'URL correspondant à l'instance Leadbay sur laquelle se trouve votre compte. Les étapes ci-dessous montrent l'URL France — sur l'instance US, remplacez simplement par `/mcp`.
+
+Il vous faut un [compte Leadbay](https://leadbay.ai/) (le même identifiant que l'application web) et l'un des assistants ci-dessous.
+
+---
+
+## Claude.ai (web)
+
+Ajoutez Leadbay comme **connecteur personnalisé**.
+
+1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)** — le formulaire s'ouvre avec le nom et l'URL pré-remplis. Laissez les paramètres avancés tels quels, puis cliquez sur **Add**.
+2. Ouvrez le connecteur **Leadbay** dans le répertoire (cherchez « Leadbay » sous **Custom connectors**), cliquez sur **Connect** et connectez-vous.
+
+Les outils Leadbay deviennent disponibles dans vos chats. Vous pouvez les cadrer par projet dans Claude Projects.
+
+> **Pas admin de l'organisation ?** Les membres ne peuvent pas ajouter un connecteur personnalisé — votre admin l'ajoute une fois (étape 1), puis vous faites **Connect** (étape 2). Voir [Configuration admin](admin-setup.md). Les connecteurs personnalisés nécessitent un plan Claude payant (Pro, Max, Team ou Enterprise).
+
+---
+
+## Claude Desktop
+
+Même **connecteur personnalisé** que Claude.ai, même URL.
+
+1. **Settings → Connectors → + → Add custom connector**
+2. **Name :** `Leadbay` · **URL :** `https://mcp.leadbay.app/fr/mcp` → cliquez sur **Add**
+3. Ouvrez le connecteur **Leadbay**, cliquez sur **Connect**, connectez-vous.
+
+Si votre premier message reçoit _« Je ne vois aucun outil Leadbay »_, les outils sont encore en train de se charger — envoyez n'importe quel deuxième message et Claude les détectera. Pas admin de l'organisation ? L'admin ajoute le connecteur d'abord (voir [Configuration admin](admin-setup.md)), ou utilisez la solution de repli par extension ci-dessous.
+
+### Solution de repli : installer l'extension
+
+Pas d'option **Add custom connector**, ou pas admin de l'organisation ? Contournez le connecteur et installez Leadbay comme **extension `.dxt`** — une installation par utilisateur en double-clic, sans droits admin.
+
+1. **[⬇ Télécharger l'extension Leadbay (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)**
+2. Double-cliquez dessus → **Install** → basculez sur **Enabled**.
+3. Ouvrez un nouveau chat, cliquez sur **Connect** sur l'extension, connectez-vous.
+
+Le double-clic n'ouvre pas Claude ? Installez depuis l'application : **Settings → Extensions → Advanced → Install extension**, puis sélectionnez le `.dxt` téléchargé. À chaque nouvelle release, téléchargez et réinstallez — Claude remplace l'ancienne version sur place et votre connexion reste valide.
+
+---
+
+## Claude Code
+
+Une seule commande enregistre Leadbay pour tous vos projets :
+
+```bash
+claude mcp add --scope user --transport http leadbay https://mcp.leadbay.app/fr/mcp
+```
+
+1. Lancez `/mcp` dans Claude Code.
+2. Sélectionnez **leadbay → Authenticate** — votre navigateur s'ouvre pour la connexion.
+3. Connectez-vous et approuvez. Le statut passe à **connected** et les outils se chargent.
+
+Vous avez lancé `add` dans une session ouverte ? Redémarrez-la une fois pour que le serveur apparaisse dans `/mcp`. Supprimez-le à tout moment avec `claude mcp remove leadbay -s user`.
+
+---
+
+## Codex
+
+Codex a une commande intégrée pour les serveurs MCP distants :
+
+```bash
+codex mcp add leadbay --url https://mcp.leadbay.app/fr/mcp
+```
+
+Codex détecte OAuth automatiquement et ouvre votre navigateur pour le flux **Se connecter avec Leadbay** — connectez-vous et approuvez. Vérifiez avec `codex mcp list` (vous devriez voir `leadbay` avec **Status: enabled**, **Auth: OAuth**). Supprimez-le avec `codex mcp remove leadbay`.
+
+---
+
+## ChatGPT
+
+Ajoutez Leadbay comme application personnalisée (connecteur MCP).
+
+1. **Settings → Apps → Advanced settings → activez Developer mode** (depuis le menu d'espace de travail en bas à gauche).
+2. De retour sur **Apps**, cliquez sur **Create app**.
+3. **Name :** `Leadbay MCP` · **Connection :** Server URL `https://mcp.leadbay.app/fr/mcp` · **Authentication :** OAuth. Cochez **I understand and want to continue** → **Create**.
+4. Cliquez sur **Sign in with Leadbay MCP**, connectez-vous et approuvez.
+
+Dans un chat, activez l'application **Leadbay MCP** depuis le menu **+** / outils du composeur pour que ChatGPT puisse appeler ses outils.
+
+> Les connecteurs MCP personnalisés nécessitent un plan ChatGPT payant (Plus, Pro, Business ou Enterprise). Sur Business/Enterprise, un admin peut devoir autoriser les connecteurs personnalisés d'abord. Si l'application se déconnecte, reconnectez-la : **Settings → Apps → Leadbay MCP → ⋯ → Reconnect**, puis reconnectez-vous.
+
+---
+
+## Après la connexion — vos premiers leads
+
+Quel que soit le client utilisé, ouvrez une nouvelle conversation et essayez :
+
+> _Montre-moi les leads du jour et dis-moi lesquels valent la peine d'être ouverts en premier._
+
+Une réponse réussie est une **liste classée** — chaque lead avec un score de fit, une raison en une ligne « pourquoi ça correspond », et le meilleur contact. Si vous voyez ça, vous êtes complètement connecté. 🎉
+
+{% content-ref url="example-prompts.md" %}
+[Exemples de prompts](example-prompts.md)
+{% endcontent-ref %}
+
+---
+
+## Dépannage
+
+| Symptôme | Solution |
+|---------|-----|
+| Erreurs « Non authentifié » / 401 | Votre connexion a expiré ou a été révoquée. Déclenchez n'importe quel outil Leadbay à nouveau et approuvez l'invite **Se connecter avec Leadbay**. |
+| Connecté, mais « montre-moi les leads » renvoie une liste vide | Vous êtes bien connecté — il n'y a simplement rien à afficher pour l'instant. Demandez _« montre-moi mes lenses »_ pour vérifier quelle audience est active. |
+| Les outils n'apparaissent pas après la connexion | Ouvrez un nouveau chat et attendez quelques secondes ; envoyez un deuxième message et les outils finissent de se charger. |
+| Les outils apparaissent mais l'assistant ne les appelle pas | Ouvrez les paramètres du connecteur et réglez les groupes d'outils Leadbay sur **Always allow** (Claude) ou activez le connecteur dans le composeur (ChatGPT). |
+| Option de connecteur personnalisé absente (Claude.ai / Claude Desktop / ChatGPT) | Les connecteurs personnalisés nécessitent un plan payant, et votre admin d'organisation peut devoir les activer — voir [Configuration admin](admin-setup.md). Sur **Claude Desktop**, vous pouvez contourner le connecteur avec la [solution de repli par extension `.dxt`](#solution-de-repli-installer-lextension). |
+| Autre problème | Signalez un bug sur [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
+
+---
+
+## Et ensuite
+
+{% content-ref url="what-is-leadbay-mcp.md" %}
+[Qu'est-ce que Leadbay MCP ?](what-is-leadbay-mcp.md)
+{% endcontent-ref %}
+
+{% content-ref url="tools-reference.md" %}
+[Référence des outils](tools-reference.md)
+{% endcontent-ref %}

--- a/fr/leadbay-mcp/quickstart.md
+++ b/fr/leadbay-mcp/quickstart.md
@@ -10,11 +10,14 @@ Il vous faut un [compte Leadbay](https://leadbay.ai/) et un assistant IA qui sup
 
 ## Étape 1 — Installer
 
-L'URL du serveur Leadbay pour la France est :
+Utilisez l'URL du serveur qui correspond à votre région :
 
-```
-https://mcp.leadbay.app/fr/mcp
-```
+| Région | URL du serveur |
+|---|---|
+| 🇫🇷 France / UE | `https://mcp.leadbay.app/fr/mcp` |
+| 🇺🇸 US | `https://mcp.leadbay.app/mcp` |
+
+Les étapes ci-dessous utilisent l'URL France — sur l'instance US, remplacez simplement par `/mcp`.
 
 **Sur Claude (web / Desktop) — connecteur personnalisé** (recommandé) :
 

--- a/fr/leadbay-mcp/quickstart.md
+++ b/fr/leadbay-mcp/quickstart.md
@@ -1,58 +1,30 @@
 # Démarrage rapide
 
-Connectez Leadbay à Claude et obtenez vos premiers leads qualifiés en environ cinq minutes. Choisissez votre client, installez, connectez-vous, et demandez — sans coder, sans jeton à copier.
+Reliez Leadbay à Claude et obtenez vos premiers leads qualifiés en environ cinq minutes. Ce guide utilise **Claude** (Claude.ai ou Claude Desktop) — le chemin le plus simple. Vous utilisez un autre assistant ? Voir [Installation](installation.md) pour la configuration pas à pas de Claude Code, ChatGPT et Codex.
 
 {% hint style="info" %}
-Il vous faut un [compte Leadbay](https://leadbay.ai/) et un assistant IA qui supporte MCP (Claude Desktop, Claude Cowork, Claude Code ou Cursor — Codex aussi). C'est tout — aucun jeton d'API à copier ou coller. _Le support de ChatGPT arrive bientôt._
+Il vous faut un [compte Leadbay](https://leadbay.ai/) et Claude (Pro, Max, Team ou Enterprise). C'est tout — aucun jeton d'API à copier ou coller ; vous ajoutez une URL et vous vous connectez avec votre navigateur.
 {% endhint %}
 
 ---
 
-## Étape 1 — Installer
+## Étape 1 — Ajouter le connecteur Leadbay
 
-Utilisez l'URL du serveur qui correspond à votre région :
+**[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**. Cette URL est celle de la France : `https://mcp.leadbay.app/fr/mcp`. Sur l'instance US, utilisez plutôt `https://mcp.leadbay.app/mcp`.
 
-| Région | URL du serveur |
-|---|---|
-| 🇫🇷 France / UE | `https://mcp.leadbay.app/fr/mcp` |
-| 🇺🇸 US | `https://mcp.leadbay.app/mcp` |
-
-Les étapes ci-dessous utilisent l'URL France — sur l'instance US, remplacez simplement par `/mcp`.
-
-**Sur Claude (web / Desktop) — connecteur personnalisé** (recommandé) :
-
-1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**. Si vous êtes en France, utilisez bien cette URL : `https://mcp.leadbay.app/fr/mcp`
-2. Ouvrez le connecteur **Leadbay**, cliquez sur **Connect** et connectez-vous.
-
-**Sur Claude Code ou Codex — une commande :**
-
-```bash
-claude mcp add --scope user --transport http leadbay https://mcp.leadbay.app/fr/mcp
-```
-
-(Pour Codex : `codex mcp add leadbay --url https://mcp.leadbay.app/fr/mcp`.)
-
-**Sur Claude Desktop sans connecteur — extension `.dxt`** (aucun droit admin requis) :
-
-1. **[⬇ Télécharger l'extension Leadbay (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)**
-2. Double-cliquez dessus → **Install** → basculez sur **Enabled**. Claude ne s'ouvre pas ? **Settings → Extensions → Advanced → Install extension**, puis sélectionnez le fichier.
+{% hint style="info" %}
+Les connecteurs personnalisés nécessitent un plan Claude payant. **Si vous n'êtes pas admin de votre organisation**, vous ne pouvez pas ajouter le connecteur vous-même — soit vous envoyez à votre admin le guide [Configuration admin](admin-setup.md) pour qu'il l'ajoute, soit, sur **Claude Desktop**, vous contournez le connecteur en installant l'[extension `.dxt`](installation.md#solution-de-repli-installer-lextension) vous-même (installation par utilisateur, sans droits admin). Voir [Installation](installation.md) pour chaque client.
+{% endhint %}
 
 ---
 
-## Étape 2 — Se connecter (cela se fait automatiquement)
+## Étape 2 — Se connecter
 
-Vous ne configurez rien à la main. Dès que vous installez — ou la première fois que Claude utilise un outil Leadbay — une page **Se connecter avec Leadbay** **s'ouvre automatiquement dans votre navigateur** :
+1. Ouvrez le nouveau connecteur **Leadbay** et cliquez sur **Connect**.
+2. Une page **Se connecter avec Leadbay** s'ouvre dans votre navigateur — connectez-vous (ou confirmez votre session existante) et cliquez sur **Approuver**.
+3. L'onglet se ferme tout seul et Claude est connecté.
 
-1. La page de connexion Leadbay apparaît d'elle-même.
-2. Connectez-vous (ou confirmez votre session existante).
-3. Cliquez sur **Approuver** pour relier Claude à votre compte.
-4. L'onglet se ferme tout seul et Claude est prêt.
-
-C'est toute la connexion. Aucun jeton, aucun fichier de config. Claude est désormais relié à **votre** compte, avec tous les leads que vous avez déjà dans Leadbay. Vous pouvez révoquer l'accès à tout moment depuis **Paramètres → Applications connectées**.
-
-{% hint style="info" %}
-Si vous avez à la fois un compte US et UE, connectez-vous sur l'instance que vous voulez que Claude utilise. Vous pouvez changer plus tard en vous déconnectant puis en vous reconnectant sur l'autre instance.
-{% endhint %}
+C'est toute la connexion — aucun jeton, aucun fichier de config. Claude est désormais relié à **votre** compte Leadbay, avec tous les leads que vous avez déjà. Vous pouvez révoquer l'accès à tout moment depuis **Paramètres → Applications connectées**.
 
 ---
 
@@ -60,9 +32,13 @@ Si vous avez à la fois un compte US et UE, connectez-vous sur l'instance que vo
 
 Ouvrez une nouvelle conversation et tapez :
 
-> *Montre-moi les leads du jour et dis-moi lesquels valent la peine d'être ouverts en premier.*
+> _Montre-moi les leads du jour et dis-moi lesquels valent la peine d'être ouverts en premier._
 
 Claude appelle vos outils Leadbay et répond avec une courte liste classée — entreprise, pourquoi elle correspond, et le meilleur contact à joindre.
+
+{% hint style="info" %}
+Votre premier message reçoit _« Je ne vois aucun outil Leadbay »_ ? Les outils sont encore en train de se charger. Envoyez n'importe quel deuxième message (même juste _« réessaie »_) et Claude les détectera.
+{% endhint %}
 
 ---
 
@@ -84,44 +60,23 @@ Si Claude répond avec des leads comme ça, vous êtes complètement connecté. 
 
 Une fois vos premiers leads affichés, essayez ceci :
 
-> *Recherche le meilleur pour moi — est-ce un bon fit ?*
+> _Recherche le meilleur pour moi — est-ce un bon fit ?_
 
-> *Rédige-moi un email de prospection pour lui.*
+> _Rédige-moi un email de prospection pour lui._
 
-> *Je viens de lui envoyer un email. Journalise-le comme prospection.*
+> _Je viens de lui envoyer un email. Journalise-le comme prospection._
 
 Claude se souvient des leads qu'il a fait remonter, vous pouvez donc continuer à parler du « meilleur » sans vous répéter.
 
 ---
 
-## Utiliser Leadbay avec Claude Desktop
+## Vous utilisez un autre assistant ?
 
-Claude Desktop charge les outils MCP plus lentement que Cowork, donc quelques précautions supplémentaires aident.
+{% content-ref url="installation.md" %}
+[Installation](installation.md)
+{% endcontent-ref %}
 
-Après avoir installé l'extension Leadbay, **quittez complètement et relancez Claude Desktop** (Cmd-Q sur Mac, puis rouvrez — pas seulement fermer la fenêtre). Ouvrez un nouveau chat et attendez environ **30 secondes** avant d'envoyer votre premier message. Cela laisse à Claude le temps de charger les outils Leadbay.
-
-Si votre premier message reçoit une réponse du type *« Je ne vois aucun outil Leadbay »* ou *« Je ne trouve pas Leadbay dans votre configuration »*, pas d'inquiétude — les outils sont encore en train de se charger. Envoyez n'importe quel deuxième message (même juste *« réessaie »*) et Claude les détectera. À partir de là, le reste de votre session fonctionne normalement.
-
----
-
-## Mise à jour
-
-Pour l'**extension `.dxt`**, quand une nouvelle release sort, répétez l'**Étape 1** (téléchargez le nouveau `.dxt`, double-cliquez, Install). Claude remplace l'ancienne version sur place ; votre connexion reste valide, vous n'avez donc pas à vous ré-authentifier.
-
-L'**installateur en une commande** exécute toujours la dernière version — il n'y a rien à mettre à jour.
-
----
-
-## Dépannage
-
-| Symptôme | Solution |
-|---------|-----|
-| Claude dit « non authentifié » ou erreurs 401 | Votre connexion a peut-être expiré ou été révoquée. Déclenchez n'importe quel outil Leadbay à nouveau et Claude relancera le flux **Se connecter avec Leadbay** |
-| Les outils n'apparaissent pas après l'installation | Vérifiez que l'extension est bien sur **Enabled** dans Settings → Extensions |
-| Les outils apparaissent mais Claude ne les appelle pas | Ouvrez **Configure** et basculez les groupes d'outils sur **Always allow** |
-| Connecté, mais « montre-moi les leads » renvoie une liste vide | Vous êtes bien connecté — il n'y a simplement rien à afficher pour l'instant. Demandez *« montre-moi mes lenses »* pour confirmer quelle audience est active et basculer si besoin, ou vérifiez que vous êtes sur la bonne instance (US vs UE) |
-| Mauvaise instance (aucun lead / erreurs 404) | Déconnectez-vous de l'extension Leadbay et reconnectez-vous sur la bonne instance (US ou UE) |
-| Autre problème | Signalez un bug sur [github.com/leadbay/leadclaw/issues](https://github.com/leadbay/leadclaw/issues) |
+Configuration pas à pas pour **Claude.ai**, **Claude Desktop**, **Claude Code**, **ChatGPT** et **Codex**. Les comptes France / UE utilisent `https://mcp.leadbay.app/fr/mcp` ; les comptes US utilisent `https://mcp.leadbay.app/mcp`.
 
 ---
 

--- a/fr/leadbay-mcp/quickstart.md
+++ b/fr/leadbay-mcp/quickstart.md
@@ -10,22 +10,29 @@ Il vous faut un [compte Leadbay](https://leadbay.ai/) et un assistant IA qui sup
 
 ## Étape 1 — Installer
 
-**Sur Claude (Desktop / Cowork) — extension `.dxt`** (recommandé) :
+L'URL du serveur Leadbay pour la France est :
 
-1. **[⬇ Télécharger l'extension Leadbay (.dxt)](https://github.com/leadbay/leadclaw/releases/latest/download/leadbay-latest.dxt)** — ceci télécharge directement la dernière version.
-2. **Double-cliquez sur le `.dxt` téléchargé.** Claude s'ouvre avec les détails de l'extension — cliquez sur **Install**, puis basculez l'extension sur **Enabled**.
-
-{% hint style="info" %}
-Claude ne s'ouvre pas ? Installez-la depuis l'application : **Settings → Extensions → Advanced → Install extension**, puis sélectionnez le fichier `.dxt`.
-{% endhint %}
-
-**Sur Claude Code, Cursor ou Codex — installateur en une commande** (nécessite [Node.js](https://nodejs.org) 22+). Il fonctionne aussi pour Claude Desktop si vous préférez automatiser la configuration :
-
-```bash
-npx -y -p @leadbay/mcp@latest installer
+```
+https://mcp.leadbay.app/fr/mcp
 ```
 
-Cela ouvre un assistant guidé qui détecte vos clients installés, ajoute Leadbay à ceux que vous choisissez, et lance le flux de connexion.
+**Sur Claude (web / Desktop) — connecteur personnalisé** (recommandé) :
+
+1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**.
+2. Ouvrez le connecteur **Leadbay**, cliquez sur **Connect** et connectez-vous.
+
+**Sur Claude Code ou Codex — une commande :**
+
+```bash
+claude mcp add --scope user --transport http leadbay https://mcp.leadbay.app/fr/mcp
+```
+
+(Pour Codex : `codex mcp add leadbay --url https://mcp.leadbay.app/fr/mcp`.)
+
+**Sur Claude Desktop sans connecteur — extension `.dxt`** (aucun droit admin requis) :
+
+1. **[⬇ Télécharger l'extension Leadbay (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)**
+2. Double-cliquez dessus → **Install** → basculez sur **Enabled**. Claude ne s'ouvre pas ? **Settings → Extensions → Advanced → Install extension**, puis sélectionnez le fichier.
 
 ---
 

--- a/fr/leadbay-mcp/quickstart.md
+++ b/fr/leadbay-mcp/quickstart.md
@@ -21,7 +21,7 @@ Les étapes ci-dessous utilisent l'URL France — sur l'instance US, remplacez s
 
 **Sur Claude (web / Desktop) — connecteur personnalisé** (recommandé) :
 
-1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**.
+1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**. Si vous êtes en France, utilisez bien cette URL : `https://mcp.leadbay.app/fr/mcp`
 2. Ouvrez le connecteur **Leadbay**, cliquez sur **Connect** et connectez-vous.
 
 **Sur Claude Code ou Codex — une commande :**

--- a/fr/leadbay-mcp/what-is-leadbay-mcp.md
+++ b/fr/leadbay-mcp/what-is-leadbay-mcp.md
@@ -5,7 +5,7 @@
 Récupérez des leads, qualifiez-les, rédigez votre prospection, journalisez vos actions — en langage naturel. Claude agit sur vos vraies données, avec vos permissions, exactement comme vous le feriez dans l'application.
 
 {% hint style="info" %}
-**MCP** signifie *Model Context Protocol* — un standard ouvert qui permet aux assistants IA comme Claude de se connecter de façon sécurisée à des outils et des données externes. Le serveur Leadbay MCP est open source et se trouve sur [github.com/leadbay/leadclaw](https://github.com/leadbay/leadclaw).
+**MCP** signifie *Model Context Protocol* — un standard ouvert qui permet aux assistants IA comme Claude de se connecter de façon sécurisée à des outils et des données externes. Le serveur Leadbay MCP est open source et se trouve sur [github.com/leadbay/mcp](https://github.com/leadbay/mcp).
 {% endhint %}
 
 ---
@@ -40,16 +40,11 @@ Leadbay MCP fonctionne avec tout assistant IA qui supporte le Model Context Prot
 
 Demandez en langage naturel — Claude répond avec une liste classée de leads qualifiés :
 
-<figure><img src="../.gitbook/assets/mcp-teaser-leads.png" alt="Claude renvoie un tableau de leads qualifiés classés dans le chat"><figcaption>« Montre-moi les leads du jour » — une liste classée avec score de fit et le meilleur contact.</figcaption></figure>
+<figure><img src="../../.gitbook/assets/mcp-teaser-leads.png" alt="Claude renvoie un tableau de leads qualifiés classés dans le chat"><figcaption>« Montre-moi les leads du jour » — une liste classée avec score de fit et le meilleur contact.</figcaption></figure>
 
 …puis rédige la prospection pour vous :
 
-<figure><img src="../.gitbook/assets/mcp-teaser-outreach.png" alt="Claude rédige un email de prospection personnalisé"><figcaption>« Rédige un email d'intro » — des variantes prêtes à envoyer en quelques secondes.</figcaption></figure>
-
-<!-- CAPTURE 3 (optionnelle) — une carte de recherche / analyse d'entreprise. Déposez l'image dans .gitbook/assets/mcp-teaser-research.png et décommentez :
-<figure><img src="../.gitbook/assets/mcp-teaser-research.png" alt="Une carte de recherche d'entreprise avec résumé de fit et meilleur contact"><figcaption>« Recherche Acme » — un résumé de fit et le meilleur contact à joindre.</figcaption></figure>
--->
-
+<figure><img src="../../.gitbook/assets/mcp-teaser-outreach.png" alt="Claude rédige un email de prospection personnalisé"><figcaption>« Rédige un email d'intro » — des variantes prêtes à envoyer en quelques secondes.</figcaption></figure>
 
 ---
 

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -8,69 +8,20 @@ If you landed here because a teammate asked you to "add the Leadbay connector" �
 you're in the right place. It takes a couple of minutes, there are no API tokens
 to hand out, and each member still signs in with **their own** Leadbay account.
 
-{% hint style="info" %}
-**Are you sure you need this?** Only **organization** plans gate custom connectors
-behind an admin:
-
-- **Claude** — Team and Enterprise workspaces.
-- **ChatGPT** — Business and Enterprise workspaces.
-
-On an individual paid plan (Claude Pro/Max, ChatGPT Plus/Pro), there's no admin
-step — you can add the connector yourself. Just follow the
-[Quickstart](quickstart.md) or [Installation](installation.md) guide.
-{% endhint %}
+> **Are you sure you need this?** Only **organization** plans gate custom connectors behind an admin — **Claude** Team/Enterprise and **ChatGPT** Business/Enterprise. On an individual paid plan (Claude Pro/Max, ChatGPT Plus/Pro) there's no admin step; add the connector yourself via the [Quickstart](quickstart.md) or [Installation](installation.md) guide.
 
 ---
 
 ## Claude (Team & Enterprise)
 
-As a **primary owner or admin**, you add Leadbay as an **organization** custom
-connector. Once it's added, it appears in every member's connector directory and
-they connect to it individually.
+As a **primary owner or admin**, add Leadbay as an **organization** custom connector. Once added, it appears in every member's directory and they connect individually.
 
-**1. Click the link below to open the Add custom connector form.** The name and
-URL are already filled in:
+1. **[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)** — the form opens with the name and URL prefilled.
+2. If Claude offers a scope choice, pick **organization** so every member gets it. Leave Advanced settings as they are (**Individual sign-in** — each member uses their own Leadbay login; you're not sharing one account), then click **Add**.
 
-{% hint style="info" %}
-[**Add the Leadbay connector →**](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)
-{% endhint %}
+That's the admin part done — Leadbay now shows up in your members' connector directory. (In a Team/Enterprise workspace members don't have the **Add custom connector** option themselves, which is why this step exists.)
 
-**2. Add it for the organization, then click Add.** If Claude offers a choice of
-scope (organization vs. just you), choose the **organization** scope so every
-member gets it. Leave the Advanced settings as they are — **Individual sign-in**
-is what you want. Each member authenticates with their own Leadbay login; you are
-**not** sharing one account across the team.
-
-<figure><img src="../.gitbook/assets/claude-01-add-custom-connector-form.png" alt="Add custom connector form with Leadbay name and URL prefilled"><figcaption><p>Name and URL are prefilled — set organization scope, then click Add</p></figcaption></figure>
-
-That's the admin part done — Leadbay now shows up in your members' connector
-directory.
-
-{% hint style="info" %}
-**Members can't add it themselves.** In a Team or Enterprise workspace, members
-don't have the **Add custom connector** option — that's exactly why this admin
-step exists.
-{% endhint %}
-
-### What your members do next
-
-Once you've added the connector, send your team these three steps (no admin
-rights needed — each person signs in with their own Leadbay account):
-
-**1. Find the Leadbay connector.** In Claude, open **Settings → Connectors** and
-search "Leadbay" — it appears under **Custom connectors**. Open it.
-
-**2. Click Connect and sign in.** A **Sign in with Leadbay** page opens in the
-browser — log in and click **Approve**. The tab closes and the connector shows as
-connected.
-
-<figure><img src="../.gitbook/assets/claude-04-connect.png" alt="Leadbay connector with the Connect button"><figcaption><p>Click Connect, then sign in with Leadbay</p></figcaption></figure>
-
-**3. Ask for leads.** Open a new chat and try _"Show me today's leads."_ Claude
-replies with a ranked shortlist — that means it's fully connected. 🎉
-
-The full member walkthrough (with the first-message tips) lives in the
-[Quickstart](quickstart.md).
+**What your members do next:** in Claude, **Settings → Connectors → search "Leadbay" → Connect**, then sign in with their own Leadbay account. Full walkthrough in the [Quickstart](quickstart.md).
 
 ---
 

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -28,31 +28,23 @@ As a **primary owner or admin**, you add Leadbay as an **organization** custom
 connector. Once it's added, it appears in every member's connector directory and
 they connect to it individually.
 
-**1. Open the Add custom connector form.** Use this link (or in Claude, go to
-**Settings → Connectors**, then the **+** next to the search bar → **Add custom
-connector**):
+**1. Click the link below to open the Add custom connector form.** The name and
+URL are already filled in:
 
 {% hint style="info" %}
-[https://claude.ai/customize/connectors?modal=add-custom-connector](https://claude.ai/customize/connectors?modal=add-custom-connector)
+[**Add the Leadbay connector →**](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)
 {% endhint %}
 
-<figure><img src="../.gitbook/assets/claude-02-connectors-plus-menu.png" alt="Connectors + menu with Add custom connector"><figcaption><p>The + menu → Add custom connector</p></figcaption></figure>
+**2. Add it for the organization, then click Add.** If Claude offers a choice of
+scope (organization vs. just you), choose the **organization** scope so every
+member gets it. Leave the Advanced settings as they are — **Individual sign-in**
+is what you want. Each member authenticates with their own Leadbay login; you are
+**not** sharing one account across the team.
 
-**2. Add it for the organization.** Fill in the fields, and if Claude offers a
-choice of scope (organization vs. just you), choose the **organization** scope so
-every member gets it:
+<figure><img src="../.gitbook/assets/claude-01-add-custom-connector-form.png" alt="Add custom connector form with Leadbay name and URL prefilled"><figcaption><p>Name and URL are prefilled — set organization scope, then click Add</p></figcaption></figure>
 
-- **Name:** `Leadbay`
-- **URL:** `https://mcp.leadbay.app/mcp`
-
-Leave the Advanced settings as they are — **Individual sign-in** is what you want.
-Each member authenticates with their own Leadbay login; you are **not** sharing
-one account across the team.
-
-<figure><img src="../.gitbook/assets/claude-01-add-custom-connector-form.png" alt="Add custom connector form with Leadbay name and URL"><figcaption><p>Name it Leadbay, paste the URL, click Add</p></figcaption></figure>
-
-**3. Click Add.** That's the admin part done — Leadbay now shows up in your
-members' connector directory.
+That's the admin part done — Leadbay now shows up in your members' connector
+directory.
 
 {% hint style="info" %}
 **Members can't add it themselves.** In a Team or Enterprise workspace, members
@@ -67,8 +59,6 @@ rights needed — each person signs in with their own Leadbay account):
 
 **1. Find the Leadbay connector.** In Claude, open **Settings → Connectors** and
 search "Leadbay" — it appears under **Custom connectors**. Open it.
-
-<figure><img src="../.gitbook/assets/claude-03-directory-search.png" alt="Directory search showing the Leadbay custom connector"><figcaption><p>Search "Leadbay" and open the connector the admin added</p></figcaption></figure>
 
 **2. Click Connect and sign in.** A **Sign in with Leadbay** page opens in the
 browser — log in and click **Approve**. The tab closes and the connector shows as

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -1,12 +1,6 @@
 # Installation
 
-Step-by-step setup for every assistant that works with Leadbay. Pick your client below — each takes a couple of minutes, and **none of them need an API token**. You add one server URL, sign in once with your Leadbay account, and you're connected.
-
-{% hint style="info" %}
-**Before you start, you need:**
-
-- A [Leadbay account](https://leadbay.ai/) (the same login you use for the web app).
-- One of the assistants below: **Claude.ai**, **Claude Desktop**, **Claude Code**, **ChatGPT**, or **Codex**.
+Pick your client below. Each takes a couple of minutes and **none of them need an API token** — you add one server URL, sign in once with your Leadbay account in the browser, and you're connected.
 
 Everywhere a server URL is asked for, it's:
 
@@ -14,8 +8,7 @@ Everywhere a server URL is asked for, it's:
 https://mcp.leadbay.app/mcp
 ```
 
-Sign-in is handled by your browser (OAuth) — there are no tokens to copy or paste.
-{% endhint %}
+You need a [Leadbay account](https://leadbay.ai/) (the same login as the web app) and one of the assistants below.
 
 ---
 
@@ -23,155 +16,77 @@ Sign-in is handled by your browser (OAuth) — there are no tokens to copy or pa
 
 Add Leadbay as a **custom connector**.
 
-**1. Click the link below, then click Add.** It opens the **Add custom connector** form in Claude with the name and URL already filled in — you just confirm:
+1. **[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)** — the form opens with the name and URL prefilled. Leave the Advanced settings as they are, then click **Add**.
+2. Open the **Leadbay** connector in the directory (search "Leadbay" under **Custom connectors**), click **Connect**, and sign in.
 
-{% hint style="info" %}
-[**Add the Leadbay connector →**](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)
-{% endhint %}
+The Leadbay tools become available in your chats. You can scope them per-project in Claude Projects.
 
-Leave the Advanced settings as they are (Individual sign-in is fine).
-
-<figure><img src="../.gitbook/assets/claude-01-add-custom-connector-form.png" alt="Add custom connector form with Leadbay name and URL prefilled"><figcaption><p>Name and URL are prefilled — just click Add</p></figcaption></figure>
-
-**2. Open the Leadbay connector and click Connect.** Find it in the directory (search "Leadbay" under **Custom connectors**), then a **Sign in with Leadbay** page opens — log in and approve. The connector shows as connected, and the Leadbay tools are available in your chats.
-
-<figure><img src="../.gitbook/assets/claude-04-connect.png" alt="Leadbay connector with the Connect button"><figcaption><p>Click Connect, then sign in with Leadbay</p></figcaption></figure>
-
-{% hint style="warning" %}
-**Not an admin of your organization?** Members can't add a custom connector themselves — your **workspace admin** needs to add the Leadbay connector first (step 1 above). Send them the [Admin setup](admin-setup.md) guide. Once the admin has added it, you'll find it in the directory and can **Connect** (step 2).
-{% endhint %}
-
-{% hint style="info" %}
-Custom connectors require a paid Claude plan (Pro, Max, Team, or Enterprise).
-{% endhint %}
+> **Not an org admin?** Members can't add a custom connector — your workspace admin adds it once (step 1), then you **Connect** (step 2). See [Admin setup](admin-setup.md). Custom connectors require a paid Claude plan (Pro, Max, Team, or Enterprise).
 
 ---
 
 ## Claude Desktop
 
-Claude Desktop connects to Leadbay exactly like Claude.ai — same **custom connector**, same URL.
+Same **custom connector** as Claude.ai, same URL.
 
-1. Open **Settings → Connectors**, click the **+** → **Add custom connector**.
-2. Enter **Name** `Leadbay` and **URL** `https://mcp.leadbay.app/mcp`, then click **Add**.
-3. Open the **Leadbay** connector and click **Connect** — sign in with Leadbay in your browser.
-4. Open a new chat and wait a few seconds for the Leadbay tools to load before your first message.
+1. **Settings → Connectors → + → Add custom connector**
+2. **Name:** `Leadbay` · **URL:** `https://mcp.leadbay.app/mcp` → click **Add**
+3. Open the **Leadbay** connector, click **Connect**, sign in.
 
-{% hint style="info" %}
-If your first message gets _"I don't see any Leadbay tools"_, the tools are still loading. Send any second message (even just _"try again"_) and Claude will pick them up. As with Claude.ai, if you're not an org admin, the admin must add the connector first — see [Admin setup](admin-setup.md).
-{% endhint %}
+If your first message gets _"I don't see any Leadbay tools"_, the tools are still loading — send any second message and Claude picks them up. Not an org admin? The admin adds the connector first (see [Admin setup](admin-setup.md)), or use the extension fallback below.
 
 ### Fallback: install the extension
 
-Can't get the custom connector to work — the **Add custom connector** option is missing, or you're not an org admin? On Claude Desktop you can skip the connector entirely and install Leadbay as a **`.dxt` extension**. It's a per-user double-click install with no admin gate.
+No **Add custom connector** option, or not an org admin? Skip the connector and install Leadbay as a **`.dxt` extension** — a per-user double-click install with no admin gate.
 
-1. **[⬇ Download the Leadbay extension (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)** — this pulls the latest version directly.
-2. **Double-click the downloaded `.dxt`.** Claude opens with the extension details — click **Install**, then toggle the extension to **Enabled**.
-3. Open a new chat, click **Connect** on the extension, and sign in with Leadbay in your browser.
+1. **[⬇ Download the Leadbay extension (.dxt)](https://github.com/leadbay/mcp/releases/latest/download/leadbay-latest.dxt)**
+2. Double-click it → **Install** → toggle to **Enabled**.
+3. Open a new chat, click **Connect** on the extension, sign in.
 
-{% hint style="info" %}
-Claude didn't open on double-click? Install it from inside the app: **Settings → Extensions → Advanced → Install extension**, then pick the `.dxt` file you downloaded. When a new release ships, download the new `.dxt` and install it again — Claude replaces the old version in place and your sign-in carries over.
-{% endhint %}
+Double-click didn't open Claude? Install from inside the app: **Settings → Extensions → Advanced → Install extension**, then pick the downloaded `.dxt`. On a new release, download and install again — Claude replaces it in place and your sign-in carries over.
 
 ---
 
 ## Claude Code
 
-One command registers Leadbay for every project.
+One command registers Leadbay for every project:
 
 ```bash
 claude mcp add --scope user --transport http leadbay https://mcp.leadbay.app/mcp
 ```
 
-Then:
-
 1. Run `/mcp` inside Claude Code.
-2. Select **leadbay** → **Authenticate**. Your browser opens for the Leadbay sign-in.
-3. Log in and approve — the status flips to **connected** and the Leadbay tools load.
+2. Select **leadbay → Authenticate** — your browser opens for sign-in.
+3. Log in and approve. The status flips to **connected** and the tools load.
 
-{% hint style="info" %}
-If you just ran the `add` command in an open Claude Code session, restart it once so the new server shows up in `/mcp`.
-{% endhint %}
-
-Remove it anytime with `claude mcp remove leadbay -s user`.
+Ran `add` in an open session? Restart it once so the server shows up in `/mcp`. Remove it anytime with `claude mcp remove leadbay -s user`.
 
 ---
 
 ## Codex
 
-Codex has a built-in command for remote MCP servers.
+Codex has a built-in command for remote MCP servers:
 
 ```bash
 codex mcp add leadbay --url https://mcp.leadbay.app/mcp
 ```
 
-Codex detects OAuth automatically and opens your browser for the **Sign in with Leadbay** flow — log in and approve. Confirm it's connected with:
-
-```bash
-codex mcp list
-```
-
-You should see `leadbay` with **Status: enabled** and **Auth: OAuth**. Remove it with `codex mcp remove leadbay`.
+Codex detects OAuth automatically and opens your browser for the **Sign in with Leadbay** flow — log in and approve. Confirm with `codex mcp list` (you should see `leadbay` with **Status: enabled**, **Auth: OAuth**). Remove it with `codex mcp remove leadbay`.
 
 ---
 
 ## ChatGPT
 
-Add Leadbay as a custom app (MCP connector) in ChatGPT.
+Add Leadbay as a custom app (MCP connector).
 
-{% hint style="info" %}
-Custom MCP connectors require a paid ChatGPT plan (Plus, Pro, Business, or Enterprise) and Developer mode, which you enable in step 5 below. On Business/Enterprise an admin may need to allow custom connectors first.
-{% endhint %}
-
-**1. Open the workspace menu** (bottom-left) and click your workspace name.
-
-<figure><img src="../.gitbook/assets/chatgpt-01-workspace-menu.png" alt="ChatGPT bottom-left workspace menu"><figcaption><p>Open the workspace menu</p></figcaption></figure>
-
-**2. Click Settings.**
-
-<figure><img src="../.gitbook/assets/chatgpt-02-settings.png" alt="Workspace menu with Settings highlighted"><figcaption><p>Click Settings</p></figcaption></figure>
-
-**3. Open the Apps tab** in the Settings sidebar.
-
-<figure><img src="../.gitbook/assets/chatgpt-03-apps.png" alt="Settings sidebar with Apps highlighted"><figcaption><p>Open the Apps tab</p></figcaption></figure>
-
-**4. Click Advanced settings.**
-
-<figure><img src="../.gitbook/assets/chatgpt-04-advanced-settings.png" alt="Apps page with Advanced settings highlighted"><figcaption><p>Click Advanced settings</p></figcaption></figure>
-
-**5. Turn on Developer mode.** This is required to add a custom MCP connector.
-
-<figure><img src="../.gitbook/assets/chatgpt-05-developer-mode.png" alt="Developer mode toggle switched on"><figcaption><p>Turn on Developer mode</p></figcaption></figure>
-
-**6. Go back to Apps and click Create app.**
-
-<figure><img src="../.gitbook/assets/chatgpt-06-create-app.png" alt="Apps page with Create app highlighted"><figcaption><p>Click Create app</p></figcaption></figure>
-
-**7. Fill in the New App form:**
-
-- **Name:** `Leadbay MCP`
-- **Connection:** select **Server URL**, then enter `https://mcp.leadbay.app/mcp`
-- **Authentication:** **OAuth**
-- Check **I understand and want to continue**, then click **Create**.
-
-<figure><img src="../.gitbook/assets/chatgpt-07-new-app-form.png" alt="New App form with name, server URL, and OAuth"><figcaption><p>Name it, set the Server URL and OAuth, then Create</p></figcaption></figure>
-
-**8. Click Sign in with Leadbay MCP.** Log in and approve — ChatGPT is now connected.
-
-<figure><img src="../.gitbook/assets/chatgpt-08-sign-in.png" alt="Sign in with Leadbay MCP prompt"><figcaption><p>Sign in with Leadbay MCP</p></figcaption></figure>
+1. **Settings → Apps → Advanced settings → turn on Developer mode** (from the bottom-left workspace menu).
+2. Back on **Apps**, click **Create app**.
+3. **Name:** `Leadbay MCP` · **Connection:** Server URL `https://mcp.leadbay.app/mcp` · **Authentication:** OAuth. Check **I understand and want to continue** → **Create**.
+4. Click **Sign in with Leadbay MCP**, log in, and approve.
 
 In a chat, enable the **Leadbay MCP** app from the composer **+** / tools menu so ChatGPT can call its tools.
 
-### If the connection has a problem
-
-If the app shows as disconnected or its tools stop responding, reconnect it:
-
-**1. Open the Leadbay MCP app** (Settings → Apps → Leadbay MCP) and click the **⋯** menu (top-right).
-
-<figure><img src="../.gitbook/assets/chatgpt-09-app-menu.png" alt="Leadbay MCP app page with the three-dot menu highlighted"><figcaption><p>Open the ⋯ menu on the Leadbay MCP app</p></figcaption></figure>
-
-**2. Click Reconnect** and sign in again.
-
-<figure><img src="../.gitbook/assets/chatgpt-10-reconnect.png" alt="App menu with Reconnect highlighted"><figcaption><p>Click Reconnect and sign in again</p></figcaption></figure>
+> Custom MCP connectors require a paid ChatGPT plan (Plus, Pro, Business, or Enterprise). On Business/Enterprise an admin may need to allow custom connectors first. If the app disconnects, reconnect it: **Settings → Apps → Leadbay MCP → ⋯ → Reconnect**, then sign in again.
 
 ---
 

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -23,33 +23,22 @@ Sign-in is handled by your browser (OAuth) — there are no tokens to copy or pa
 
 Add Leadbay as a **custom connector**.
 
-**1. Open the Add custom connector form.** Click this link (or in Claude, go to **Settings → Connectors**, then the **+** next to the search bar → **Add custom connector**):
+**1. Click the link below, then click Add.** It opens the **Add custom connector** form in Claude with the name and URL already filled in — you just confirm:
 
 {% hint style="info" %}
-[https://claude.ai/customize/connectors?modal=add-custom-connector](https://claude.ai/customize/connectors?modal=add-custom-connector)
+[**Add the Leadbay connector →**](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)
 {% endhint %}
-
-<figure><img src="../.gitbook/assets/claude-02-connectors-plus-menu.png" alt="Connectors + menu with Add custom connector"><figcaption><p>The + menu → Add custom connector</p></figcaption></figure>
-
-**2. Fill in the fields and click Add:**
-
-- **Name:** `Leadbay`
-- **URL:** `https://mcp.leadbay.app/mcp`
 
 Leave the Advanced settings as they are (Individual sign-in is fine).
 
-<figure><img src="../.gitbook/assets/claude-01-add-custom-connector-form.png" alt="Add custom connector form with Leadbay name and URL"><figcaption><p>Name it Leadbay, paste the URL, click Add</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/claude-01-add-custom-connector-form.png" alt="Add custom connector form with Leadbay name and URL prefilled"><figcaption><p>Name and URL are prefilled — just click Add</p></figcaption></figure>
 
-**3. Find the Leadbay connector** in the directory (search "Leadbay" — it appears under **Custom connectors**) and open it.
-
-<figure><img src="../.gitbook/assets/claude-03-directory-search.png" alt="Directory search showing the Leadbay custom connector"><figcaption><p>Your new Leadbay custom connector</p></figcaption></figure>
-
-**4. Click Connect** and sign in. A **Sign in with Leadbay** page opens — log in and approve. The connector shows as connected, and the Leadbay tools are available in your chats.
+**2. Open the Leadbay connector and click Connect.** Find it in the directory (search "Leadbay" under **Custom connectors**), then a **Sign in with Leadbay** page opens — log in and approve. The connector shows as connected, and the Leadbay tools are available in your chats.
 
 <figure><img src="../.gitbook/assets/claude-04-connect.png" alt="Leadbay connector with the Connect button"><figcaption><p>Click Connect, then sign in with Leadbay</p></figcaption></figure>
 
 {% hint style="warning" %}
-**Not an admin of your organization?** Members can't add a custom connector themselves — your **workspace admin** needs to add the Leadbay connector first (steps 1–2 above). Send them the [Admin setup](admin-setup.md) guide. Once the admin has added it, you'll find it in the directory and can **Connect** (steps 3–4).
+**Not an admin of your organization?** Members can't add a custom connector themselves — your **workspace admin** needs to add the Leadbay connector first (step 1 above). Send them the [Admin setup](admin-setup.md) guide. Once the admin has added it, you'll find it in the directory and can **Connect** (step 2).
 {% endhint %}
 
 {% hint style="info" %}

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -2,11 +2,14 @@
 
 Pick your client below. Each takes a couple of minutes and **none of them need an API token** — you add one server URL, sign in once with your Leadbay account in the browser, and you're connected.
 
-Everywhere a server URL is asked for, it's:
+Everywhere a server URL is asked for, use the one for your region:
 
-```
-https://mcp.leadbay.app/mcp
-```
+| Region | Server URL |
+|---|---|
+| 🇺🇸 US (default) | `https://mcp.leadbay.app/mcp` |
+| 🇫🇷 France / EU | `https://mcp.leadbay.app/fr/mcp` |
+
+Use the URL that matches the Leadbay instance your account is on. The steps below show the US URL — French users just swap in `/fr/mcp`.
 
 You need a [Leadbay account](https://leadbay.ai/) (the same login as the web app) and one of the assistants below.
 

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -76,7 +76,7 @@ Claude remembers the leads it surfaced, so you can keep referring to "the top on
 [Installation](installation.md)
 {% endcontent-ref %}
 
-Step-by-step setup for **Claude.ai**, **Claude Desktop**, **Claude Code**, **ChatGPT**, and **Codex** — they all use the same `https://mcp.leadbay.app/mcp` endpoint.
+Step-by-step setup for **Claude.ai**, **Claude Desktop**, **Claude Code**, **ChatGPT**, and **Codex**. US accounts use `https://mcp.leadbay.app/mcp`; France / EU use `https://mcp.leadbay.app/fr/mcp`.
 
 ---
 

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -10,7 +10,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 
 ## Step 1 — Add the Leadbay connector
 
-**[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)** — the **Add custom connector** form opens with the name (`Leadbay`) and URL (`https://mcp.leadbay.app/mcp`) already filled in. Click **Add**.
+**[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)**, then click **Add**.
 
 {% hint style="info" %}
 Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for every client.

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -10,15 +10,10 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 
 ## Step 1 — Add the Leadbay connector
 
-1. Open the **Add custom connector** form — use this link, or in Claude go to **Settings → Connectors** → the **+** → **Add custom connector**:
-   - [https://claude.ai/customize/connectors?modal=add-custom-connector](https://claude.ai/customize/connectors?modal=add-custom-connector)
-2. Enter:
-   - **Name:** `Leadbay`
-   - **URL:** `https://mcp.leadbay.app/mcp`
-3. Click **Add**.
+**[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)** — the **Add custom connector** form opens with the name (`Leadbay`) and URL (`https://mcp.leadbay.app/mcp`) already filled in. Click **Add**.
 
 {% hint style="info" %}
-Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for the full walkthrough with screenshots.
+Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for every client.
 {% endhint %}
 
 ---

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -10,7 +10,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 
 ## Step 1 — Add the Leadbay connector
 
-**[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)**, then click **Add**.
+**[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)**, then click **Add**. If you're in France, use this URL instead: `https://mcp.leadbay.app/fr/mcp`
 
 {% hint style="info" %}
 Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for every client.


### PR DESCRIPTION
Refactors the Leadbay-MCP install docs to a terse, Modjo-style layout, adds the region-aware endpoint, and brings the French docs to full parity with English.

**English pages**
- **installation.md** — short numbered lists with breadcrumb arrows, inline URLs, no step screenshots. ChatGPT goes from 8 steps + 10 shots to 4 lines. Claude.ai/Desktop use the prefilled one-click connector link.
- **admin-setup.md** — Claude org-connector flow down to 2 lines + a one-line "what members do next".
- **quickstart.md** — Step 1 uses the prefilled one-click link.

**Region endpoint** — stated up front on installation.md + both quickstarts: US → `https://mcp.leadbay.app/mcp`, France/EU → `https://mcp.leadbay.app/fr/mcp`. Quickstart Step 1 calls out the alternate URL right after "click Add".

**French parity** (fr/leadbay-mcp) — now mirrors the EN section 1:1:
- new `installation.md` + `admin-setup.md` (translated, default `/fr/mcp`, US `/mcp` shown as alternative)
- `quickstart.md` rewritten to the EN 3-step connector shape (was an older `.dxt`-first flow)
- `what-is-leadbay-mcp.md` drift fixed (repo link, asset paths)
- `fr/SUMMARY.md` gains Installation + Configuration admin nav entries
- `tools-reference.md` / `example-prompts.md` were already faithful 1:1 — untouched

**Screenshots:** the 12 EN step screenshots (`claude-01..04`, `chatgpt-01..10`) are now unreferenced but left on disk — say if you'd like them deleted. Result/teaser screenshots are kept in both languages.