### PR TITLE
docs(mcp): name both server URLs (US + FR) in EN and FR quickstart

### DIFF
--- a/fr/leadbay-mcp/admin-setup.md
+++ b/fr/leadbay-mcp/admin-setup.md
@@ -12,7 +12,7 @@ Si vous êtes arrivé ici parce qu'un collègue vous a demandé d'« ajouter le 
 
 En tant que **propriétaire principal ou admin**, ajoutez Leadbay comme connecteur personnalisé d'**organisation**. Une fois ajouté, il apparaît dans le répertoire de chaque membre et ils se connectent individuellement.
 
-1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)** — le formulaire s'ouvre avec le nom et l'URL pré-remplis. (URL France : `https://mcp.leadbay.app/fr/mcp` ; sur l'instance US, utilisez `https://mcp.leadbay.app/mcp`.)
+1. **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)** — le formulaire s'ouvre avec le nom et l'URL pré-remplis. (Il existe deux URLs de serveur : ce lien utilise celle de la France, `https://mcp.leadbay.app/fr/mcp` ; pour un espace de travail US, utilisez plutôt `https://mcp.leadbay.app/mcp`.)
 2. Si Claude propose un choix de portée, choisissez **organisation** pour que chaque membre en bénéficie. Laissez les paramètres avancés tels quels (**Individual sign-in** — chaque membre utilise son propre identifiant Leadbay ; vous ne partagez pas un seul compte), puis cliquez sur **Add**.
 
 C'est fait côté admin — Leadbay apparaît maintenant dans le répertoire de connecteurs de vos membres. (Dans un espace Team/Enterprise, les membres n'ont pas l'option **Add custom connector** eux-mêmes, c'est pourquoi cette étape existe.)

--- a/fr/leadbay-mcp/installation.md
+++ b/fr/leadbay-mcp/installation.md
@@ -2,14 +2,14 @@
 
 Choisissez votre client ci-dessous. Chacun prend deux minutes et **aucun ne nécessite de jeton d'API** — vous ajoutez une URL de serveur, vous vous connectez une fois avec votre compte Leadbay dans le navigateur, et c'est relié.
 
-Partout où une URL de serveur est demandée, utilisez celle de votre région :
+Il existe **deux URLs de serveur** — choisissez celle correspondant à l'instance Leadbay sur laquelle se trouve votre compte :
 
 | Région | URL du serveur |
 |---|---|
 | 🇫🇷 France / UE | `https://mcp.leadbay.app/fr/mcp` |
 | 🇺🇸 US | `https://mcp.leadbay.app/mcp` |
 
-Utilisez l'URL correspondant à l'instance Leadbay sur laquelle se trouve votre compte. Les étapes ci-dessous montrent l'URL France — sur l'instance US, remplacez simplement par `/mcp`.
+Les étapes ci-dessous montrent l'URL France — sur l'instance US, remplacez simplement par `/mcp`.
 
 Il vous faut un [compte Leadbay](https://leadbay.ai/) (le même identifiant que l'application web) et l'un des assistants ci-dessous.
 

--- a/fr/leadbay-mcp/quickstart.md
+++ b/fr/leadbay-mcp/quickstart.md
@@ -10,7 +10,7 @@ Il vous faut un [compte Leadbay](https://leadbay.ai/) et Claude (Pro, Max, Team 
 
 ## Étape 1 — Ajouter le connecteur Leadbay
 
-**[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**. Cette URL est celle de la France : `https://mcp.leadbay.app/fr/mcp`. Sur l'instance US, utilisez plutôt `https://mcp.leadbay.app/mcp`.
+**[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**. Il existe deux URLs de serveur — ce lien utilise celle de la France, `https://mcp.leadbay.app/fr/mcp`. Sur l'instance US, utilisez plutôt `https://mcp.leadbay.app/mcp`.
 
 {% hint style="info" %}
 Les connecteurs personnalisés nécessitent un plan Claude payant. **Si vous n'êtes pas admin de votre organisation**, vous ne pouvez pas ajouter le connecteur vous-même — soit vous envoyez à votre admin le guide [Configuration admin](admin-setup.md) pour qu'il l'ajoute, soit, sur **Claude Desktop**, vous contournez le connecteur en installant l'[extension `.dxt`](installation.md#solution-de-repli-installer-lextension) vous-même (installation par utilisateur, sans droits admin). Voir [Installation](installation.md) pour chaque client.

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -16,7 +16,7 @@ to hand out, and each member still signs in with **their own** Leadbay account.
 
 As a **primary owner or admin**, add Leadbay as an **organization** custom connector. Once added, it appears in every member's directory and they connect individually.
 
-1. **[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)** — the form opens with the name and URL prefilled.
+1. **[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)** — the form opens with the name and URL prefilled. (There are two server URLs: this link uses the US one, `https://mcp.leadbay.app/mcp`; for a France / EU workspace, use `https://mcp.leadbay.app/fr/mcp` instead.)
 2. If Claude offers a scope choice, pick **organization** so every member gets it. Leave Advanced settings as they are (**Individual sign-in** — each member uses their own Leadbay login; you're not sharing one account), then click **Add**.
 
 That's the admin part done — Leadbay now shows up in your members' connector directory. (In a Team/Enterprise workspace members don't have the **Add custom connector** option themselves, which is why this step exists.)

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -1,15 +1,15 @@
 # Installation
 
-Pick your client below. Each takes a couple of minutes and **none of them need an API token** — you add one server URL, sign in once with your Leadbay account in the browser, and you're connected.
+Pick your client below. Each takes a couple of minutes and **none of them need an API token** — you add a server URL, sign in once with your Leadbay account in the browser, and you're connected.
 
-Everywhere a server URL is asked for, use the one for your region:
+There are **two server URLs** — pick the one that matches the Leadbay instance your account is on:
 
 | Region | Server URL |
 |---|---|
 | 🇺🇸 US (default) | `https://mcp.leadbay.app/mcp` |
 | 🇫🇷 France / EU | `https://mcp.leadbay.app/fr/mcp` |
 
-Use the URL that matches the Leadbay instance your account is on. The steps below show the US URL — French users just swap in `/fr/mcp`.
+The steps below show the US URL — French users just swap in `/fr/mcp`.
 
 You need a [Leadbay account](https://leadbay.ai/) (the same login as the web app) and one of the assistants below.
 

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -10,7 +10,7 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 
 ## Step 1 — Add the Leadbay connector
 
-**[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)**, then click **Add**. If you're in France, use this URL instead: `https://mcp.leadbay.app/fr/mcp`
+**[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)**, then click **Add**. There are two server URLs — this link uses the US one, `https://mcp.leadbay.app/mcp`. If you're in France, use `https://mcp.leadbay.app/fr/mcp` instead.
 
 {% hint style="info" %}
 Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for every client.


### PR DESCRIPTION
Makes it explicit in **both** quickstarts that there are two Leadbay MCP server URLs, and names each — so users on either side know the other exists:

- 🇺🇸 US — `https://mcp.leadbay.app/mcp`
- 🇫🇷 France / EU — `https://mcp.leadbay.app/fr/mcp`

The EN quickstart previously only mentioned the French URL as an aside; it now states both symmetrically, matching the FR quickstart. Both Step 1 sections read the same way.