### PR TITLE
docs(mcp): lead the Quickstart with a 'which one are you?' router

### DIFF
--- a/fr/leadbay-mcp/quickstart.md
+++ b/fr/leadbay-mcp/quickstart.md
@@ -8,12 +8,25 @@ Il vous faut un [compte Leadbay](https://leadbay.ai/) et Claude (Pro, Max, Team 
 
 ---
 
+## D'abord — vous êtes dans quel cas ?
+
+Ajouter un connecteur personnalisé nécessite un **plan Claude payant**, et dans un **espace de travail d'entreprise, seul un admin peut l'ajouter**. Trouvez votre situation, puis suivez les étapes ci-dessous :
+
+| Votre situation | Que faire |
+|---|---|
+| **Solo / plan payant personnel** (pas dans un espace d'entreprise) | Ajoutez-le vous-même — suivez l'Étape 1 ci-dessous. |
+| **Dans un espace d'entreprise, et vous êtes l'admin** | Ajoutez-le vous-même (Étape 1) — vos collègues n'ont plus qu'à faire **Connect**. |
+| **Dans un espace d'entreprise, pas admin** | Vous ne pouvez pas l'ajouter vous-même. Envoyez à votre admin le guide [Configuration admin](admin-setup.md) ; une fois qu'il l'a ajouté, passez directement à l'**Étape 2 — Se connecter**. |
+| **Impossible d'ajouter un connecteur / pas d'admin à qui demander** | Sur **Claude Desktop**, installez plutôt l'[extension `.dxt`](installation.md#solution-de-repli-installer-lextension) — une installation par utilisateur, sans verrou admin. |
+
+---
+
 ## Étape 1 — Ajouter le connecteur Leadbay
 
 **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**. Il existe deux URLs de serveur — ce lien utilise celle de la France, `https://mcp.leadbay.app/fr/mcp`. Sur l'instance US, utilisez plutôt `https://mcp.leadbay.app/mcp`.
 
 {% hint style="info" %}
-Les connecteurs personnalisés nécessitent un plan Claude payant. **Si vous n'êtes pas admin de votre organisation**, vous ne pouvez pas ajouter le connecteur vous-même — soit vous envoyez à votre admin le guide [Configuration admin](admin-setup.md) pour qu'il l'ajoute, soit, sur **Claude Desktop**, vous contournez le connecteur en installant l'[extension `.dxt`](installation.md#solution-de-repli-installer-lextension) vous-même (installation par utilisateur, sans droits admin). Voir [Installation](installation.md) pour chaque client.
+Vous préférez des captures d'écran pas à pas, ou vous êtes sur un autre assistant (Claude Desktop, Claude Code, ChatGPT, Codex) ? Voir le guide complet d'[Installation](installation.md).
 {% endhint %}
 
 ---

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -8,12 +8,25 @@ You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team,
 
 ---
 
+## First — which one are you?
+
+Adding a custom connector needs a **paid Claude plan**, and in a **company workspace only an admin can add it**. Find your situation, then follow the steps below:
+
+| Your situation | What to do |
+|---|---|
+| **Solo / personal paid plan** (not in a company workspace) | Add it yourself — follow Step 1 below. |
+| **In a company workspace, and you're the admin** | Add it yourself (Step 1) — your teammates then just **Connect**. |
+| **In a company workspace, not the admin** | You can't add it yourself. Send your admin the [Admin setup](admin-setup.md) guide; once they've added it, skip to **Step 2 — Sign in**. |
+| **Can't add connectors / no admin to ask** | On **Claude Desktop**, install the [`.dxt` extension](installation.md#fallback-install-the-extension) instead — a per-user install with no admin gate. |
+
+---
+
 ## Step 1 — Add the Leadbay connector
 
 **[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)**, then click **Add**. There are two server URLs — this link uses the US one, `https://mcp.leadbay.app/mcp`. If you're in France, use `https://mcp.leadbay.app/fr/mcp` instead.
 
 {% hint style="info" %}
-Custom connectors require a paid Claude plan. **If you're not an admin of your organization**, you can't add the connector yourself — either send your workspace admin the [Admin setup](admin-setup.md) guide so they add it, or, on **Claude Desktop**, skip the connector entirely and install the [`.dxt` extension](installation.md#fallback-install-the-extension) yourself (a per-user, no-admin install). See [Installation](installation.md) for every client.
+Prefer step-by-step screenshots, or on a different assistant (Claude Desktop, Claude Code, ChatGPT, Codex)? See the full [Installation](installation.md) walkthrough.
 {% endhint %}
 
 ---


### PR DESCRIPTION
## Problem
The one fact that gates the whole Quickstart — *"can I even add this connector?"* (paid plan + admin-only in a company workspace) — is buried in a mid-step hint. A non-technical reader only finds out whether they can proceed *after* trying.

## Fix (EN Quickstart only, surgical)
Add a **"First — which one are you?"** table at the top, before Step 1, so users self-route in one glance:

| Situation | Action |
|---|---|
| Solo / personal paid plan | Add it yourself |
| Company workspace, you're the admin | Add it yourself; teammates Connect |
| Company workspace, not admin | Send admin the Admin setup guide → then Connect |
| Can't add / no admin | Claude Desktop `.dxt` (no-admin install) |

Then trim the now-redundant mid-step hint to a pointer to the full Installation walkthrough. No step content changed; +14/−1.

## Note
Re-applies the idea from #16 on top of current `main` — that branch conflicted after the Quickstart was rewritten (region endpoints, prefilled link). #16 to be closed as superseded. The stale-FR-quickstart concern #16 flagged is already fixed on `main`.