### PR TITLE
docs(mcp): add GitHub Copilot installation (EN + FR)

### DIFF
--- a/fr/leadbay-mcp/installation.md
+++ b/fr/leadbay-mcp/installation.md
@@ -78,6 +78,31 @@ Codex détecte OAuth automatiquement et ouvre votre navigateur pour le flux **Se
 
 ---
 
+## GitHub Copilot (VS Code)
+
+GitHub Copilot prend en charge les serveurs MCP distants avec OAuth en un clic — aucun jeton, aucune installation locale. Nécessite **VS Code 1.99+**.
+
+1. Ouvrez la palette de commandes (`Ctrl/Cmd+Shift+P`) → lancez **MCP: Add Server** → choisissez **HTTP** → collez `https://mcp.leadbay.app/fr/mcp` → nommez-le `leadbay` → choisissez **Workspace** (écrit `.vscode/mcp.json`) ou **Global**.
+2. Un lien **Start** apparaît au-dessus de la nouvelle entrée — cliquez dessus. Votre navigateur s'ouvre pour le flux **Se connecter avec Leadbay** ; connectez-vous et approuvez.
+3. Dans Copilot Chat, passez le mode sur **Agent**, puis ouvrez l'icône **Tools** et vérifiez que **leadbay** est activé.
+
+Vous préférez l'ajouter à la main ? Collez ceci dans `.vscode/mcp.json` (ou votre `mcp.json` utilisateur), puis cliquez sur **Start** :
+
+```json
+{
+  "servers": {
+    "leadbay": {
+      "type": "http",
+      "url": "https://mcp.leadbay.app/fr/mcp"
+    }
+  }
+}
+```
+
+Les outils MCP ne fonctionnent que dans le mode **Agent** de Copilot Chat — en mode **Ask** ou **Edit**, vous ne verrez pas les outils Leadbay.
+
+---
+
 ## ChatGPT
 
 Ajoutez Leadbay comme application personnalisée (connecteur MCP).

--- a/fr/leadbay-mcp/quickstart.md
+++ b/fr/leadbay-mcp/quickstart.md
@@ -1,6 +1,6 @@
 # Démarrage rapide
 
-Reliez Leadbay à Claude et obtenez vos premiers leads qualifiés en environ cinq minutes. Ce guide utilise **Claude** (Claude.ai ou Claude Desktop) — le chemin le plus simple. Vous utilisez un autre assistant ? Voir [Installation](installation.md) pour la configuration pas à pas de Claude Code, ChatGPT et Codex.
+Reliez Leadbay à Claude et obtenez vos premiers leads qualifiés en environ cinq minutes. Ce guide utilise **Claude** (Claude.ai ou Claude Desktop) — le chemin le plus simple. Vous utilisez un autre assistant ? Voir [Installation](installation.md) pour la configuration pas à pas de Claude Code, Codex, GitHub Copilot et ChatGPT.
 
 {% hint style="info" %}
 Il vous faut un [compte Leadbay](https://leadbay.ai/) et Claude (Pro, Max, Team ou Enterprise). C'est tout — aucun jeton d'API à copier ou coller ; vous ajoutez une URL et vous vous connectez avec votre navigateur.
@@ -26,7 +26,7 @@ Ajouter un connecteur personnalisé nécessite un **plan Claude payant**, et dan
 **[Ajouter le connecteur Leadbay →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Ffr%2Fmcp)**, puis cliquez sur **Add**. Il existe deux URLs de serveur — ce lien utilise celle de la France, `https://mcp.leadbay.app/fr/mcp`. Sur l'instance US, utilisez plutôt `https://mcp.leadbay.app/mcp`.
 
 {% hint style="info" %}
-Vous préférez des captures d'écran pas à pas, ou vous êtes sur un autre assistant (Claude Desktop, Claude Code, ChatGPT, Codex) ? Voir le guide complet d'[Installation](installation.md).
+Vous préférez des captures d'écran pas à pas, ou vous êtes sur un autre assistant (Claude Desktop, Claude Code, Codex, GitHub Copilot, ChatGPT) ? Voir le guide complet d'[Installation](installation.md).
 {% endhint %}
 
 ---
@@ -89,7 +89,7 @@ Claude se souvient des leads qu'il a fait remonter, vous pouvez donc continuer �
 [Installation](installation.md)
 {% endcontent-ref %}
 
-Configuration pas à pas pour **Claude.ai**, **Claude Desktop**, **Claude Code**, **ChatGPT** et **Codex**. Les comptes France / UE utilisent `https://mcp.leadbay.app/fr/mcp` ; les comptes US utilisent `https://mcp.leadbay.app/mcp`.
+Configuration pas à pas pour **Claude.ai**, **Claude Desktop**, **Claude Code**, **Codex**, **GitHub Copilot** et **ChatGPT**. Les comptes France / UE utilisent `https://mcp.leadbay.app/fr/mcp` ; les comptes US utilisent `https://mcp.leadbay.app/mcp`.
 
 ---
 

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -78,6 +78,31 @@ Codex detects OAuth automatically and opens your browser for the **Sign in with 
 
 ---
 
+## GitHub Copilot (VS Code)
+
+GitHub Copilot supports remote MCP servers with one-click OAuth — no token, no local install. Needs **VS Code 1.99+**.
+
+1. Open the Command Palette (`Ctrl/Cmd+Shift+P`) → run **MCP: Add Server** → choose **HTTP** → paste `https://mcp.leadbay.app/mcp` → name it `leadbay` → pick **Workspace** (writes `.vscode/mcp.json`) or **Global**.
+2. A **Start** link appears above the new entry — click it. Your browser opens for the **Sign in with Leadbay** flow; log in and approve.
+3. In Copilot Chat, switch the mode to **Agent**, then open the **Tools** icon and make sure **leadbay** is enabled.
+
+Prefer to add it by hand? Drop this into `.vscode/mcp.json` (or your user `mcp.json`), then click **Start**:
+
+```json
+{
+  "servers": {
+    "leadbay": {
+      "type": "http",
+      "url": "https://mcp.leadbay.app/mcp"
+    }
+  }
+}
+```
+
+MCP tools only run in Copilot Chat's **Agent** mode — in **Ask** or **Edit** mode you won't see the Leadbay tools.
+
+---
+
 ## ChatGPT
 
 Add Leadbay as a custom app (MCP connector).

--- a/leadbay-mcp/quickstart.md
+++ b/leadbay-mcp/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Connect Leadbay to Claude and get your first qualified leads in about five minutes. This guide uses **Claude** (Claude.ai or Claude Desktop) — the simplest path. Using a different assistant? See [Installation](installation.md) for step-by-step setup of Claude Code, ChatGPT, and Codex.
+Connect Leadbay to Claude and get your first qualified leads in about five minutes. This guide uses **Claude** (Claude.ai or Claude Desktop) — the simplest path. Using a different assistant? See [Installation](installation.md) for step-by-step setup of Claude Code, Codex, GitHub Copilot, and ChatGPT.
 
 {% hint style="info" %}
 You'll need a [Leadbay account](https://leadbay.ai/) and Claude (Pro, Max, Team, or Enterprise). That's it — no API tokens to copy or paste; you add one URL and sign in with your browser.
@@ -26,7 +26,7 @@ Adding a custom connector needs a **paid Claude plan**, and in a **company works
 **[Add the Leadbay connector →](https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Leadbay&connectorUrl=https%3A%2F%2Fmcp.leadbay.app%2Fmcp)**, then click **Add**. There are two server URLs — this link uses the US one, `https://mcp.leadbay.app/mcp`. If you're in France, use `https://mcp.leadbay.app/fr/mcp` instead.
 
 {% hint style="info" %}
-Prefer step-by-step screenshots, or on a different assistant (Claude Desktop, Claude Code, ChatGPT, Codex)? See the full [Installation](installation.md) walkthrough.
+Prefer step-by-step screenshots, or on a different assistant (Claude Desktop, Claude Code, Codex, GitHub Copilot, ChatGPT)? See the full [Installation](installation.md) walkthrough.
 {% endhint %}
 
 ---
@@ -89,7 +89,7 @@ Claude remembers the leads it surfaced, so you can keep referring to "the top on
 [Installation](installation.md)
 {% endcontent-ref %}
 
-Step-by-step setup for **Claude.ai**, **Claude Desktop**, **Claude Code**, **ChatGPT**, and **Codex**. US accounts use `https://mcp.leadbay.app/mcp`; France / EU use `https://mcp.leadbay.app/fr/mcp`.
+Step-by-step setup for **Claude.ai**, **Claude Desktop**, **Claude Code**, **Codex**, **GitHub Copilot**, and **ChatGPT**. US accounts use `https://mcp.leadbay.app/mcp`; France / EU use `https://mcp.leadbay.app/fr/mcp`.
 
 ---
 


### PR DESCRIPTION
Adds **GitHub Copilot (VS Code)** to the MCP installation docs — the one coding assistant not yet covered alongside Claude Code, Codex, Claude.ai/Desktop, and ChatGPT.

**What changed**
- New `## GitHub Copilot (VS Code)` section on both install pages — `leadbay-mcp/installation.md` (US `/mcp`) and `fr/leadbay-mcp/installation.md` (FR `/fr/mcp`). Covers the `MCP: Add Server` → HTTP flow, the `.vscode/mcp.json` config block, the **Start** → one-click OAuth sign-in, and the Agent-mode + Tools-icon requirement (VS Code 1.99+).
- GitHub Copilot added to the "other assistant" enumeration lines in both quickstarts (EN + FR).

Matches the existing per-client `##`-section pattern, so no SUMMARY/nav change. Docs-only (GitBook content repo — no build/test suite); the install steps and JSON shape were cross-checked against current VS Code / GitHub Copilot MCP docs.

Closes https://github.com/leadbay/product/issues/3890