### PR TITLE
Fix French docs parity

### DIFF
--- a/fr/contact-us/support.md
+++ b/fr/contact-us/support.md
@@ -1,9 +1,9 @@
-# Support
+# ☎️ Support
 
-Une question, un bug repéré, ou simplement envie de nous faire un retour ?
+Une question, un bug repéré, ou simplement envie de nous faire un retour ?<br>
 
 Nous serons ravis de vous entendre :
 
-* [Écrivez-nous sur WhatsApp](https://wa.me/33679814876?text=Bonjour%20Leadbay%20!)
-* [Envoyez un email au support](mailto:support@leadbay.ai)
-* [Laissez un mot sur notre Wall of Love](https://airtable.com/appAF5Qt556zU5sgB/shrJgLxYlDcNm7sOx)
+* [Écrivez-nous sur WhatsApp](https://wa.me/33679814876?text=Bonjour%20Leadbay%20!) (🤳🏼)
+* [Envoyez un email au support](mailto:support@leadbay.ai) (📩)&#x20;
+* [Laissez un mot sur notre Wall of Love](https://airtable.com/appAF5Qt556zU5sgB/shrJgLxYlDcNm7sOx) (❤️)

--- a/fr/leadbay-mcp/what-is-leadbay-mcp.md
+++ b/fr/leadbay-mcp/what-is-leadbay-mcp.md
@@ -46,6 +46,10 @@ Demandez en langage naturel — Claude répond avec une liste classée de leads 
 
 <figure><img src="../../.gitbook/assets/mcp-teaser-outreach.png" alt="Claude rédige un email de prospection personnalisé"><figcaption>« Rédige un email d'intro » — des variantes prêtes à envoyer en quelques secondes.</figcaption></figure>
 
+<!-- CAPTURE 3 (optionnelle) — une fiche de recherche / analyse détaillée d'entreprise. Ajoutez l'image dans .gitbook/assets/mcp-teaser-research.png et décommentez :
+<figure><img src="../../.gitbook/assets/mcp-teaser-research.png" alt="Une fiche de recherche d'entreprise avec résumé de fit et meilleur contact"><figcaption>« Recherche Acme » — un résumé de fit et le meilleur contact à joindre.</figcaption></figure>
+-->
+
 ---
 
 ## Pour commencer

--- a/fr/product-guides/contact-enrichment.md
+++ b/fr/product-guides/contact-enrichment.md
@@ -20,11 +20,11 @@ Testé sur différents secteurs et types d'entreprises.
 
 1. Ouvrez la fiche d'un lead, onglet **Contacts**
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-08-20 à 10.56.03.png" alt="" width="366"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-08-20 à 10.56.03.png" alt="" width="366"><figcaption></figcaption></figure>
 
 2. Cliquez sur **Enrich** sur un contact suggéré
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-08-20 à 10.57.03.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-08-20 à 10.57.03.png" alt="" width="375"><figcaption></figcaption></figure>
 
 3. Attendez quelques secondes (2 minutes max)
 4. Vous n'êtes facturé que si les données sont trouvées

--- a/fr/product-guides/install-mobile-app.md
+++ b/fr/product-guides/install-mobile-app.md
@@ -3,42 +3,42 @@ description: >-
   L'installation prend moins d'une minute. Pour iPhone et Android.
 ---
 
-# Installer l'application mobile
+# 📱 Installer l'application mobile
 
 ### Sur iPhone
 
 1. Copiez ce [lien](https://go.leadbay.app/) dans votre navigateur **Safari** puis appuyez sur « accéder ».
 2. Cliquez sur l'icône Partager en bas de votre écran.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.12.53.png" alt="" width="179"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.12.53.png" alt="" width="179"><figcaption></figcaption></figure>
 
 3. Cliquez sur « Sur l'écran d'accueil ».
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.12.59.png" alt="" width="188"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.12.59.png" alt="" width="188"><figcaption></figcaption></figure>
 
 4. Cliquez sur « Ajouter ».
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.13.06.png" alt="" width="188"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.13.06.png" alt="" width="188"><figcaption></figcaption></figure>
 
 5. L'application apparaîtra automatiquement sur votre écran d'accueil.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.13.26.png" alt="" width="185"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.13.26.png" alt="" width="185"><figcaption></figcaption></figure>
 
 ### Sur Android
 
 1. Copiez ce [lien](https://go.leadbay.app/) dans votre navigateur.
 2. Cliquez sur l'icône menu en haut à droite de votre navigateur.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.29.44.png" alt="" width="173"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.29.44.png" alt="" width="173"><figcaption></figcaption></figure>
 
 3. Appuyez sur « Ajouter à l'écran d'accueil ».
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.29.51.png" alt="" width="170"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.29.51.png" alt="" width="170"><figcaption></figcaption></figure>
 
 4. Cliquez sur « Installer ».
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.29.56.png" alt="" width="165"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.29.56.png" alt="" width="165"><figcaption></figcaption></figure>
 
 5. L'application apparaîtra automatiquement sur votre écran d'accueil.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-01-07 à 15.30.07.png" alt="" width="168"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-01-07 à 15.30.07.png" alt="" width="168"><figcaption></figcaption></figure>

--- a/fr/product-guides/manager-dashboard.md
+++ b/fr/product-guides/manager-dashboard.md
@@ -14,6 +14,8 @@ Ouvrez le menu latéral (icône hamburger, en haut à gauche) et cliquez sur **D
 
 ## Filtres
 
+En haut du Dashboard, deux contrôles :
+
 - **Sélecteur de membres** : un, plusieurs ou tous les membres de l'équipe
 - **Période** : 3 derniers mois, dernier mois, dernière semaine, ou personnalisée
 
@@ -34,7 +36,7 @@ Chaque ligne correspond à un membre de l'équipe. Utilisez ce tableau pour rep�
 
 ## Graphique d'évolution
 
-Le graphique montre les tendances dans le temps. Activez/désactivez les métriques avec les cases à cocher.
+Sous le tableau, un graphique montre l'évolution dans le temps pour chaque métrique. Activez/désactivez les métriques avec les cases à cocher pour vous concentrer sur ce qui compte.
 
 Ce graphique capture **chaque interaction** — les chiffres peuvent être plus élevés que la liste de leads (un utilisateur peut interagir plusieurs fois avec le même lead).
 

--- a/fr/product-guides/onboarding.md
+++ b/fr/product-guides/onboarding.md
@@ -12,7 +12,7 @@ Lors de votre première inscription, Leadbay vous guide à travers un **onboardi
 
 Nous vous demanderons votre nom, email et un mot de passe. Vous vérifierez ensuite votre email en cliquant sur un lien que nous vous envoyons.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-08-20 à 10.44.33.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-08-20 à 10.44.33.png" alt="" width="375"><figcaption></figcaption></figure>
 
 ## Étape 2 — Parlez-nous de vos affaires passées
 
@@ -22,7 +22,7 @@ Pour personnaliser les recommandations, notre IA a besoin d'un aperçu de vos le
 
 Fournissez un fichier CSV avec vos données CRM passées. Il n'a pas besoin d'être parfait ni complet — plus il est riche, mieux c'est, mais nous travaillons avec ce que vous nous donnez.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-08-20 à 10.50.22.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-08-20 à 10.50.22.png" alt="" width="375"><figcaption></figcaption></figure>
 
 Comment exporter depuis votre CRM :
 
@@ -33,13 +33,13 @@ Comment exporter depuis votre CRM :
 
 Chaque CRM nomme les choses différemment. Leadbay détecte automatiquement vos colonnes — vérifiez ou corrigez le mapping.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-08-20 à 10.51.00.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-08-20 à 10.51.00.png" alt="" width="375"><figcaption></figcaption></figure>
 
 Le champ le plus important est **Status** — il indique à notre IA quels leads ont été gagnés ou perdus. C'est ainsi que le modèle apprend quel type de leads fonctionne pour vous.
 
 Nous vous demanderons aussi de confirmer comment vous nommez vos statuts.
 
-<figure><img src="../../.gitbook/assets/Capture d'écran 2025-08-20 à 10.51.36.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Capture d’écran 2025-08-20 à 10.51.36.png" alt="" width="375"><figcaption></figcaption></figure>
 
 Une fois terminé, vous verrez votre première sélection de leads recommandés par l'IA.
 

--- a/fr/product-guides/team-management.md
+++ b/fr/product-guides/team-management.md
@@ -6,11 +6,13 @@ Gérez les paramètres de votre organisation et les membres de votre équipe dep
 
 ## Informations de l'organisation
 
-Ouvrez le menu latéral et allez dans **My Organization**.
+Ouvrez le menu latéral (icône hamburger, en haut à gauche) et allez dans **My Organization**.
 
 <figure><img src="../../.gitbook/assets/screenshot-team-organization.png" alt=""><figcaption><p>Paramètres de l'organisation</p></figcaption></figure>
 
-Vous pouvez consulter et modifier le **nom de votre organisation**.
+Ici, vous pouvez :
+
+- Consulter et modifier le **nom de votre organisation**
 
 ---
 

--- a/product-guides/contact-enrichment.md
+++ b/product-guides/contact-enrichment.md
@@ -20,11 +20,11 @@ Tested across various industries and company types.
 
 1. Open a lead profile and go to the **Contacts** tab,
 
-<figure><img src="../.gitbook/assets/Capture d'écran 2025-08-20 à 10.56.03.png" alt="" width="366"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/Capture d’écran 2025-08-20 à 10.56.03.png" alt="" width="366"><figcaption></figcaption></figure>
 
 2. Click **Enrich** on any suggested contact,
 
-<figure><img src="../.gitbook/assets/Capture d'écran 2025-08-20 à 10.57.03.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/Capture d’écran 2025-08-20 à 10.57.03.png" alt="" width="375"><figcaption></figcaption></figure>
 
 3. Wait a few seconds (max 2 minutes),
 4. You're only charged if the data is found.

--- a/product-guides/onboarding.md
+++ b/product-guides/onboarding.md
@@ -12,7 +12,7 @@ When you first sign up, Leadbay walks you through an **8-step guided onboarding*
 
 We'll ask for your name, email, and a password. You'll then verify your email by clicking a link we send you.
 
-<figure><img src="../.gitbook/assets/Capture d'écran 2025-08-20 à 10.44.33.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/Capture d’écran 2025-08-20 à 10.44.33.png" alt="" width="375"><figcaption></figcaption></figure>
 
 ## Step 2 — Tell us about your past wins
 
@@ -22,7 +22,7 @@ To personalize recommendations, our AI needs a glimpse into your past leads.
 
 Provide a CSV file with past CRM data. It doesn't have to be perfect or complete — the more the better, but we'll work with what you give us.
 
-<figure><img src="../.gitbook/assets/Capture d'écran 2025-08-20 à 10.50.22.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/Capture d’écran 2025-08-20 à 10.50.22.png" alt="" width="375"><figcaption></figcaption></figure>
 
 How to export from your CRM:
 
@@ -33,13 +33,13 @@ How to export from your CRM:
 
 Every CRM calls things by different names. Leadbay auto-detects your columns — verify or correct the mapping.
 
-<figure><img src="../.gitbook/assets/Capture d'écran 2025-08-20 à 10.51.00.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/Capture d’écran 2025-08-20 à 10.51.00.png" alt="" width="375"><figcaption></figcaption></figure>
 
 The most important field is **Status** — it tells our AI which leads were won or lost. This is how the model learns what kind of leads work for you.
 
 We'll also ask you to confirm how you name your statuses.
 
-<figure><img src="../.gitbook/assets/Capture d'écran 2025-08-20 à 10.51.36.png" alt="" width="375"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/Capture d’écran 2025-08-20 à 10.51.36.png" alt="" width="375"><figcaption></figcaption></figure>
 
 Once done, you'll see your first selection of AI-recommended leads.
 


### PR DESCRIPTION
## Summary
- align French docs with matching English page structure/details
- update ChatGPT MCP setup to use the current Plugins + flow with Name: Leadbay and region-specific connection URLs
- fix broken GitBook screenshot asset paths in onboarding and contact enrichment docs

## Checks
- stale ChatGPT Settings/Developer-mode wording search
- paired English/French page structure check
- local markdown link/asset resolution check
- git diff --check