### PR TITLE
Update ChatGPT MCP installation docs

### DIFF
--- a/fr/leadbay-mcp/admin-setup.md
+++ b/fr/leadbay-mcp/admin-setup.md
@@ -26,20 +26,24 @@ C'est fait côté admin — Leadbay apparaît maintenant dans le répertoire de 
 Sur les espaces Business et Enterprise, les connecteurs MCP personnalisés sont désactivés jusqu'à ce qu'un **propriétaire ou admin d'espace de travail** les autorise. Vous n'ajoutez pas Leadbay pour tout le monde ici — vous débloquez la possibilité, et chaque membre l'ajoute ensuite lui-même.
 
 1. Ouvrez les **paramètres de votre espace de travail** (menu d'espace, en bas à gauche → **Settings**).
-2. Sous les contrôles de connecteurs / apps, **autorisez les connecteurs personnalisés** pour l'espace de travail (c'est l'interrupteur au niveau de l'espace qui débloque les apps personnalisées en Developer mode pour les membres).
+2. Sous les contrôles de plugins / connecteurs, **autorisez les plugins/connecteurs personnalisés** pour l'espace de travail.
 3. Prévenez vos membres qu'ils peuvent désormais ajouter Leadbay.
 
 ### Ce que font vos membres ensuite
 
-Contrairement à Claude, les membres ChatGPT ajoutent l'application eux-mêmes une fois que vous avez autorisé les connecteurs personnalisés. Envoyez-leur la section **ChatGPT** du guide [Installation](installation.md) — chaque membre :
+Contrairement à Claude, les membres ChatGPT ajoutent la connexion eux-mêmes une fois que vous avez autorisé les plugins/connecteurs personnalisés. Envoyez-leur la section **ChatGPT** du guide [Installation](installation.md) — chaque membre :
 
-1. Active le **Developer mode** (Settings → Apps → Advanced settings).
-2. Clique sur **Create app** et remplit **Name** `Leadbay MCP`, **Server URL** `https://mcp.leadbay.app/fr/mcp`, et **Authentication : OAuth**.
-3. Clique sur **Sign in with Leadbay MCP** et se connecte avec son propre compte Leadbay.
-4. Active l'application **Leadbay MCP** depuis le menu **+** / outils du composeur, puis demande des leads.
+1. Active le mode développeur dans **Settings → Security and Login** en descendant tout en bas, puis en activant **Developer mode**.
+2. Ouvre **Plugins** dans ChatGPT.
+3. Clique sur **+** pour ajouter une nouvelle connexion.
+4. Renseigne **Name** `Leadbay` et la bonne **Connection URL** :
+   `https://mcp.leadbay.app/fr/mcp` pour les espaces France / UE, ou
+   `https://mcp.leadbay.app/mcp` pour les espaces US.
+5. Clique sur **Connect**, se connecte avec son propre compte Leadbay et approuve.
+6. Active **Leadbay** depuis le menu **+** / plugins du composeur, puis demande des leads.
 
 {% hint style="info" %}
-La formulation et l'emplacement exacts du contrôle « autoriser les connecteurs personnalisés » évoluent avec la console admin de ChatGPT. Si vous ne le trouvez pas, cherchez **connectors** ou **apps** dans les paramètres de l'espace, ou consultez la documentation admin actuelle d'OpenAI.
+La formulation et l'emplacement exacts du contrôle « autoriser les plugins/connecteurs personnalisés » évoluent avec la console admin de ChatGPT. Si vous ne le trouvez pas, cherchez **plugins** ou **connectors** dans les paramètres de l'espace, ou consultez la documentation admin actuelle d'OpenAI.
 {% endhint %}
 
 {% hint style="info" %}

--- a/fr/leadbay-mcp/installation.md
+++ b/fr/leadbay-mcp/installation.md
@@ -80,16 +80,20 @@ Codex détecte OAuth automatiquement et ouvre votre navigateur pour le flux **Se
 
 ## ChatGPT
 
-Ajoutez Leadbay comme application personnalisée (connecteur MCP).
+Ajoutez Leadbay comme connexion de plugin personnalisée (connecteur MCP).
 
-1. **Settings → Apps → Advanced settings → activez Developer mode** (depuis le menu d'espace de travail en bas à gauche).
-2. De retour sur **Apps**, cliquez sur **Create app**.
-3. **Name :** `Leadbay MCP` · **Connection :** Server URL `https://mcp.leadbay.app/fr/mcp` · **Authentication :** OAuth. Cochez **I understand and want to continue** → **Create**.
-4. Cliquez sur **Sign in with Leadbay MCP**, connectez-vous et approuvez.
+1. Activez le mode développeur : ouvrez **Settings → Security and Login**, descendez tout en bas, puis activez **Developer mode**.
+2. Ouvrez **Plugins** dans ChatGPT.
+3. Cliquez sur **+** pour ajouter une nouvelle connexion.
+4. **Name :** `Leadbay`
+5. **Connection URL :** utilisez l'URL correspondant à votre espace Leadbay :
+   - France / UE : `https://mcp.leadbay.app/fr/mcp`
+   - US : `https://mcp.leadbay.app/mcp`
+6. Cliquez sur **Connect**, puis connectez-vous avec votre compte Leadbay et approuvez.
 
-Dans un chat, activez l'application **Leadbay MCP** depuis le menu **+** / outils du composeur pour que ChatGPT puisse appeler ses outils.
+Dans un chat, activez **Leadbay** depuis le menu **+** / plugins du composeur pour que ChatGPT puisse appeler ses outils.
 
-> Les connecteurs MCP personnalisés nécessitent un plan ChatGPT payant (Plus, Pro, Business ou Enterprise). Sur Business/Enterprise, un admin peut devoir autoriser les connecteurs personnalisés d'abord. Si l'application se déconnecte, reconnectez-la : **Settings → Apps → Leadbay MCP → ⋯ → Reconnect**, puis reconnectez-vous.
+> Les connecteurs MCP personnalisés nécessitent un plan ChatGPT payant (Plus, Pro, Business ou Enterprise). Sur Business/Enterprise, un admin peut devoir autoriser les plugins/connecteurs personnalisés d'abord. Si Leadbay se déconnecte, ouvrez **Plugins**, sélectionnez **Leadbay**, puis reconnectez-vous.
 
 ---
 
@@ -114,8 +118,8 @@ Une réponse réussie est une **liste classée** — chaque lead avec un score d
 | Erreurs « Non authentifié » / 401 | Votre connexion a expiré ou a été révoquée. Déclenchez n'importe quel outil Leadbay à nouveau et approuvez l'invite **Se connecter avec Leadbay**. |
 | Connecté, mais « montre-moi les leads » renvoie une liste vide | Vous êtes bien connecté — il n'y a simplement rien à afficher pour l'instant. Demandez _« montre-moi mes lenses »_ pour vérifier quelle audience est active. |
 | Les outils n'apparaissent pas après la connexion | Ouvrez un nouveau chat et attendez quelques secondes ; envoyez un deuxième message et les outils finissent de se charger. |
-| Les outils apparaissent mais l'assistant ne les appelle pas | Ouvrez les paramètres du connecteur et réglez les groupes d'outils Leadbay sur **Always allow** (Claude) ou activez le connecteur dans le composeur (ChatGPT). |
-| Option de connecteur personnalisé absente (Claude.ai / Claude Desktop / ChatGPT) | Les connecteurs personnalisés nécessitent un plan payant, et votre admin d'organisation peut devoir les activer — voir [Configuration admin](admin-setup.md). Sur **Claude Desktop**, vous pouvez contourner le connecteur avec la [solution de repli par extension `.dxt`](#solution-de-repli-installer-lextension). |
+| Les outils apparaissent mais l'assistant ne les appelle pas | Ouvrez les paramètres du connecteur et réglez les groupes d'outils Leadbay sur **Always allow** (Claude) ou activez le plugin Leadbay dans le composeur (ChatGPT). |
+| Option de connecteur/plugin personnalisé absente (Claude.ai / Claude Desktop / ChatGPT) | Les connecteurs/plugins personnalisés nécessitent un plan payant, et votre admin d'organisation peut devoir les activer — voir [Configuration admin](admin-setup.md). Sur **Claude Desktop**, vous pouvez contourner le connecteur avec la [solution de repli par extension `.dxt`](#solution-de-repli-installer-lextension). |
 | Autre problème | Signalez un bug sur [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
 
 ---

--- a/leadbay-mcp/admin-setup.md
+++ b/leadbay-mcp/admin-setup.md
@@ -32,29 +32,30 @@ On Business and Enterprise workspaces, custom MCP connectors are off until a
 — you unlock the ability, and each member then adds it themselves.
 
 1. Open your **workspace settings** (workspace menu, bottom-left → **Settings**).
-2. Under the connector / apps controls, **allow custom connectors** for the
-   workspace (this is the workspace-level switch that gates Developer-mode custom
-   apps for members).
+2. Under the plugin / connector controls, **allow custom plugins/connectors** for
+   the workspace.
 3. Let your members know they can now add Leadbay.
 
 ### What your members do next
 
-Unlike Claude, ChatGPT members add the app themselves once you've allowed custom
-connectors. Send them the **ChatGPT** section of the
+Unlike Claude, ChatGPT members add the plugin connection themselves once you've allowed custom
+plugins/connectors. Send them the **ChatGPT** section of the
 [Installation](installation.md) guide — each member:
 
-1. Turns on **Developer mode** (Settings → Apps → Advanced settings).
-2. Clicks **Create app** and fills in **Name** `Leadbay MCP`, **Server URL**
-   `https://mcp.leadbay.app/mcp`, and **Authentication: OAuth**.
-3. Clicks **Sign in with Leadbay MCP** and logs in with their own Leadbay account.
-4. Enables the **Leadbay MCP** app from the composer **+** / tools menu, then asks
-   for leads.
+1. Enables developer mode in **Settings → Security and Login** by scrolling to the bottom and turning on **Developer mode**.
+2. Opens **Plugins** in ChatGPT.
+3. Clicks **+** to add a new connection.
+4. Enters **Name** `Leadbay` and the correct **Connection URL**:
+   `https://mcp.leadbay.app/mcp` for US workspaces, or
+   `https://mcp.leadbay.app/fr/mcp` for France / EU workspaces.
+5. Clicks **Connect**, signs in with their own Leadbay account, and approves.
+6. Enables **Leadbay** from the composer **+** / plugin menu, then asks for leads.
 
 {% hint style="info" %}
-The exact wording and location of the "allow custom connectors" control changes
-as ChatGPT's admin console evolves. If you can't find it, search the workspace
-settings for **connectors** or **apps**, or check OpenAI's current admin
-documentation.
+The exact wording and location of the "allow custom plugins/connectors" control
+changes as ChatGPT's admin console evolves. If you can't find it, search the
+workspace settings for **plugins** or **connectors**, or check OpenAI's current
+admin documentation.
 {% endhint %}
 
 {% hint style="info" %}

--- a/leadbay-mcp/installation.md
+++ b/leadbay-mcp/installation.md
@@ -80,16 +80,20 @@ Codex detects OAuth automatically and opens your browser for the **Sign in with 
 
 ## ChatGPT
 
-Add Leadbay as a custom app (MCP connector).
+Add Leadbay as a custom plugin connection (MCP connector).
 
-1. **Settings → Apps → Advanced settings → turn on Developer mode** (from the bottom-left workspace menu).
-2. Back on **Apps**, click **Create app**.
-3. **Name:** `Leadbay MCP` · **Connection:** Server URL `https://mcp.leadbay.app/mcp` · **Authentication:** OAuth. Check **I understand and want to continue** → **Create**.
-4. Click **Sign in with Leadbay MCP**, log in, and approve.
+1. Enable developer mode: open **Settings → Security and Login**, scroll to the bottom, and turn on **Developer mode**.
+2. Open **Plugins** in ChatGPT.
+3. Click **+** to add a new connection.
+4. **Name:** `Leadbay`
+5. **Connection URL:** use the URL for your Leadbay workspace:
+   - US: `https://mcp.leadbay.app/mcp`
+   - France / EU: `https://mcp.leadbay.app/fr/mcp`
+6. Click **Connect**, then sign in with your Leadbay account and approve.
 
-In a chat, enable the **Leadbay MCP** app from the composer **+** / tools menu so ChatGPT can call its tools.
+In a chat, enable **Leadbay** from the composer **+** / plugin menu so ChatGPT can call its tools.
 
-> Custom MCP connectors require a paid ChatGPT plan (Plus, Pro, Business, or Enterprise). On Business/Enterprise an admin may need to allow custom connectors first. If the app disconnects, reconnect it: **Settings → Apps → Leadbay MCP → ⋯ → Reconnect**, then sign in again.
+> Custom MCP connectors require a paid ChatGPT plan (Plus, Pro, Business, or Enterprise). On Business/Enterprise an admin may need to allow custom plugins/connectors first. If Leadbay disconnects, open **Plugins**, select **Leadbay**, and reconnect.
 
 ---
 
@@ -114,8 +118,8 @@ A successful reply is a **ranked shortlist** — each lead with a fit score, a o
 | "Not authenticated" / 401 errors | Your sign-in expired or was revoked. Trigger any Leadbay tool again and approve the **Sign in with Leadbay** prompt. |
 | Connected, but "show me leads" returns an empty list | You're signed in fine — there's just nothing to show right now. Ask _"show me my lenses"_ to check which audience is active. |
 | Tools don't appear after connecting | Open a new chat and wait a few seconds; send a second message and the tools finish loading. |
-| Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the connector in the composer (ChatGPT). |
-| Custom connector option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](#fallback-install-the-extension). |
+| Tools appear but the assistant won't call them | Open the connector settings and set the Leadbay tool groups to **Always allow** (Claude) or enable the Leadbay plugin in the composer (ChatGPT). |
+| Custom connector/plugin option missing (Claude.ai / Claude Desktop / ChatGPT) | Custom connectors/plugins need a paid plan, and your workspace admin may need to enable them — see [Admin setup](admin-setup.md). On **Claude Desktop** you can skip the connector entirely with the [`.dxt` extension fallback](#fallback-install-the-extension). |
 | Other issue | File a bug at [github.com/leadbay/mcp/issues](https://github.com/leadbay/mcp/issues). |
 
 ---


### PR DESCRIPTION
## Summary
- update ChatGPT MCP setup to use the current Plugins + flow, not Apps
- add the Developer mode prerequisite: Settings → Security and Login → Enable Developer mode
- document Name: Leadbay and region-specific connection URLs for US and France / EU
- align the ChatGPT admin setup instructions in English and French

## Checks
- ChatGPT install wording search
- local markdown link/asset resolution check
- git diff --check